### PR TITLE
fix for RUC LSM imprecision issue

### DIFF
--- a/physics/lsm_ruc.F90
+++ b/physics/lsm_ruc.F90
@@ -1043,6 +1043,20 @@ module lsm_ruc
         z0_lnd(i,j)  = z0rl_lnd(i)/100.
         znt_lnd(i,j) = z0rl_lnd(i)/100.
 
+        ! Workaround needed for subnormal numbers.  This should be
+        ! done after all other sanity checks, in case a sanity check
+        ! results in subnormal numbers.
+        !
+        ! This bug was caught by the UFS gfortran debug-mode
+        ! regression tests, and the fix is necessary to pass those
+        ! tests.
+        if(abs(snowh_lnd(i,j))<1e-20) then
+          snowh_lnd(i,j)=0
+        endif
+        if(abs(sneqv_lnd(i,j))<1e-20) then
+          sneqv_lnd(i,j)=0
+        endif
+
         if(debug_print) then
           if(me==0 ) then
             write (0,*)'before LSMRUC for land'
@@ -1359,6 +1373,19 @@ module lsm_ruc
 
         z0_ice(i,j)  = z0rl_ice(i)/100.
         znt_ice(i,j) = z0rl_ice(i)/100.
+
+        ! Workaround needed for subnormal numbers.  This should be
+        ! done after all other sanity checks, in case a sanity check
+        ! results in subnormal numbers.
+        !
+        ! Although this bug has not been triggered yet, it is expected
+        ! to be, like the _lnd variants many lines up from here.
+        if(abs(snowh_ice(i,j))<1e-20) then
+          snowh_ice(i,j)=0
+        endif
+        if(abs(sneqv_ice(i,j))<1e-20) then
+          sneqv_ice(i,j)=0
+        endif
 
 !> - Call RUC LSM lsmruc() for ice.
       call lsmruc(                                                           &

--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -521,6 +521,15 @@ CONTAINS
 
       DO i=its,ite
 
+         IF(ABS(SNOWH(I,J))<1e-20) THEN
+           ! Workaround needed for subnormal numbers (gfortran issue)
+           SNOWH(I,J)=0
+         ENDIF
+         IF(ABS(SNOW(I,J))<1e-20) THEN
+           ! Workaround needed for subnormal numbers (gfortran issue)
+           SNOW(I,J)=0
+         ENDIF
+
     IF (debug_print ) THEN
 !     if(j==10) then
       print *,' IN LSMRUC ','ims,ime,jms,jme,its,ite,jts,jte,nzs', &

--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -521,15 +521,6 @@ CONTAINS
 
       DO i=its,ite
 
-         IF(ABS(SNOWH(I,J))<1e-20) THEN
-           ! Workaround needed for subnormal numbers (gfortran issue)
-           SNOWH(I,J)=0
-         ENDIF
-         IF(ABS(SNOW(I,J))<1e-20) THEN
-           ! Workaround needed for subnormal numbers (gfortran issue)
-           SNOW(I,J)=0
-         ENDIF
-
     IF (debug_print ) THEN
 !     if(j==10) then
       print *,' IN LSMRUC ','ims,ime,jms,jme,its,ite,jts,jte,nzs', &


### PR DESCRIPTION
The module_sf_ruclsm.F90 has comparisons to zero, which break the code when numbers are very close to 0, such as 1e-322. This happens with the gfortran compiler when compled with `-DDEBUG=ON` since the option to truncate subnormal numbers is turned off. It might also happen if the ruc lsm was run in double precision, but I have not seen that yet. My fix is truncate subnormal numbers manually, for the two variables that cause trouble. This new code is in the "sanity checks" regions of lsm_ruc.F90, as requested by @tanyasmirnova.

Fixes #5