### PR TITLE
Modify the Thompson scheme to improve radiative fluxes and cloud cover for HR1

### DIFF
--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -750,8 +750,7 @@
                 qc_mp (i,k) = tracer1(i,k,ntcw)/(1.-qvs)
                 qi_mp (i,k) = tracer1(i,k,ntiw)/(1.-qvs)
                 qs_mp (i,k) = tracer1(i,k,ntsw)/(1.-qvs)
-                !nc_mp (i,k) = nt_c*orho(i,k)
-                if(slmsk(i) == 0.) then
+                if(nint(slmsk(i)) == 0) then
                   nc_mp (i,k) = Nt_c_o*orho(i,k)
                 else
                   nc_mp (i,k) = Nt_c_l*orho(i,k)

--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -750,10 +750,10 @@
                 qc_mp (i,k) = tracer1(i,k,ntcw)/(1.-qvs)
                 qi_mp (i,k) = tracer1(i,k,ntiw)/(1.-qvs)
                 qs_mp (i,k) = tracer1(i,k,ntsw)/(1.-qvs)
-                if(nint(slmsk(i)) == 0) then
-                  nc_mp (i,k) = Nt_c_o*orho(i,k)
-                else
+                if(nint(slmsk(i)) == 1) then
                   nc_mp (i,k) = Nt_c_l*orho(i,k)
+                else
+                  nc_mp (i,k) = Nt_c_o*orho(i,k)
                 endif
                 ni_mp (i,k) = tracer1(i,k,ntinc)/(1.-qvs)
               enddo

--- a/physics/GFS_rrtmgp_cloud_mp.F90
+++ b/physics/GFS_rrtmgp_cloud_mp.F90
@@ -865,10 +865,10 @@ contains
                nc_mp(iCol,iLay) = make_DropletNumber(qc_mp(iCol,iLay)*rho, nwfa(iCol,iLay)*rho) * orho
              endif
           else
-             if (nint(lsmask(iCol)) == 0) then !land
-                nc_mp(iCol,iLay) = nt_c_o*orho
-             else 
+             if (nint(lsmask(iCol)) == 1) then !land
                 nc_mp(iCol,iLay) = nt_c_l*orho
+             else 
+                nc_mp(iCol,iLay) = nt_c_o*orho
              endif 
           endif
           if (qi_mp(iCol,iLay) > 1.e-12 .and. ni_mp(iCol,iLay) < 100.) then

--- a/physics/GFS_rrtmgp_cloud_mp.F90
+++ b/physics/GFS_rrtmgp_cloud_mp.F90
@@ -12,8 +12,8 @@ module GFS_rrtmgp_cloud_mp
   use rrtmgp_lw_cloud_optics, only: &
        radliq_lwr => radliq_lwrLW, radliq_upr => radliq_uprLW,&
        radice_lwr => radice_lwrLW, radice_upr => radice_uprLW  
-  use module_mp_thompson, only: calc_effectRad, Nt_c, re_qc_min, re_qc_max, re_qi_min, &
-       re_qi_max, re_qs_min, re_qs_max
+  use module_mp_thompson, only: calc_effectRad, Nt_c_l, Nt_c_o, re_qc_min, re_qc_max,  &
+       re_qi_min, re_qi_max, re_qs_min, re_qs_max
   use module_mp_thompson_make_number_concentrations, only: make_IceNumber,             &
        make_DropletNumber, make_RainNumber
   
@@ -254,7 +254,7 @@ contains
        ! Update particle size using modified mixing-ratios from Thompson.
        call cmp_reff_Thompson(nLev, nCol, i_cldliq, i_cldice, i_cldsnow, i_cldice_nc,   &
             i_cldliq_nc, i_twa, q_lay, p_lay, t_lay, tracer, con_eps, con_rd, ltaerosol,&
-            mraerosol, effrin_cldliq, effrin_cldice, effrin_cldsnow)
+            mraerosol, lsmask,  effrin_cldliq, effrin_cldice, effrin_cldsnow)
        cld_reliq  = effrin_cldliq
        cld_reice  = effrin_cldice
        cld_resnow = effrin_cldsnow
@@ -820,7 +820,7 @@ contains
 !! \section cmp_reff_Thompson_gen General Algorithm
   subroutine cmp_reff_Thompson(nLev, nCol, i_cldliq, i_cldice, i_cldsnow, i_cldice_nc,   &
        i_cldliq_nc, i_twa, q_lay, p_lay, t_lay, tracer, con_eps, con_rd, ltaerosol,      &
-       mraerosol, effrin_cldliq, effrin_cldice, effrin_cldsnow)
+       mraerosol, lsmask, effrin_cldliq, effrin_cldice, effrin_cldsnow)
     implicit none
 
     ! Inputs
@@ -830,6 +830,7 @@ contains
     real(kind_phys), intent(in) :: con_eps,con_rd
     real(kind_phys), dimension(:,:),intent(in) :: q_lay, p_lay, t_lay
     real(kind_phys), dimension(:,:,:),intent(in) :: tracer
+    real(kind_phys), dimension(:), intent(in) :: lsmask
 
     ! Outputs
     real(kind_phys), dimension(:,:), intent(inout) :: effrin_cldliq, effrin_cldice,      &
@@ -840,6 +841,7 @@ contains
     real(kind_phys) :: rho, orho
     real(kind_phys),dimension(nCol,nLev) :: qv_mp, qc_mp, qi_mp, qs_mp, ni_mp, nc_mp,    &
          nwfa, re_cloud, re_ice, re_snow
+    integer :: ilsmask 
 
     ! Prepare cloud mixing-ratios and number concentrations for calc_effectRa
     do iLay = 1, nLev
@@ -863,7 +865,11 @@ contains
                nc_mp(iCol,iLay) = make_DropletNumber(qc_mp(iCol,iLay)*rho, nwfa(iCol,iLay)*rho) * orho
              endif
           else
-             nc_mp(iCol,iLay) = nt_c*orho
+             if (nint(lsmask(iCol)) == 0) then !land
+                nc_mp(iCol,iLay) = nt_c_o*orho
+             else 
+                nc_mp(iCol,iLay) = nt_c_l*orho
+             endif 
           endif
           if (qi_mp(iCol,iLay) > 1.e-12 .and. ni_mp(iCol,iLay) < 100.) then
              ni_mp(iCol,iLay) = make_IceNumber(qi_mp(iCol,iLay)*rho, t_lay(iCol,iLay)) * orho
@@ -873,9 +879,11 @@ contains
 
     ! Compute effective radii for liquid/ice/snow.
     do iCol=1,nCol
+       ilsmask = nint(lsmask(iCol))
        call calc_effectRad (t_lay(iCol,:), p_lay(iCol,:), qv_mp(iCol,:), qc_mp(iCol,:),  &
                             nc_mp(iCol,:), qi_mp(iCol,:), ni_mp(iCol,:), qs_mp(iCol,:),  &
-                            re_cloud(iCol,:), re_ice(iCol,:), re_snow(iCol,:), 1, nLev )
+                            re_cloud(iCol,:), re_ice(iCol,:), re_snow(iCol,:), ilsmask,  & 
+                            1, nLev )
        do iLay = 1, nLev
           re_cloud(iCol,iLay) = MAX(re_qc_min, MIN(re_cloud(iCol,iLay), re_qc_max))
           re_ice(iCol,iLay)   = MAX(re_qi_min, MIN(re_ice(iCol,iLay),   re_qi_max))

--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -92,7 +92,6 @@ MODULE module_mp_thompson
 !.. scheme.  In 2-moment cloud water, Nt_c represents a maximum of
 !.. droplet concentration and nu_c is also variable depending on local
 !.. droplet number concentration.
-      !REAL, PARAMETER :: Nt_c = 100.E6
       REAL, PARAMETER :: Nt_c_o = 50.E6
       REAL, PARAMETER :: Nt_c_l = 100.E6
       REAL, PARAMETER, PRIVATE:: Nt_c_max = 1999.E6
@@ -110,7 +109,6 @@ MODULE module_mp_thompson
       REAL, PARAMETER, PRIVATE:: mu_r = 0.0
       REAL, PARAMETER, PRIVATE:: mu_g = 0.0
       REAL, PARAMETER, PRIVATE:: mu_i = 0.0
-      !REAL, PRIVATE:: mu_c
       REAL, PRIVATE::  mu_c_o, mu_c_l
 
 !..Sum of two gamma distrib for snow (Field et al. 2005).
@@ -153,7 +151,6 @@ MODULE module_mp_thompson
       REAL, PARAMETER, PRIVATE:: fv_s = 100.0
       REAL, PARAMETER, PRIVATE:: av_g = 442.0
       REAL, PARAMETER, PRIVATE:: bv_g = 0.89
-     !REAL, PARAMETER, PRIVATE:: av_i = 1493.9
       REAL, PARAMETER, PRIVATE:: bv_i = 1.0
       REAL, PARAMETER, PRIVATE:: av_c = 0.316946E8
       REAL, PARAMETER, PRIVATE:: bv_c = 2.0
@@ -537,7 +534,6 @@ MODULE module_mp_thompson
 !.. disp=SQRT((mu+2)/(mu+1) - 1) so mu varies from 15 for Maritime
 !.. to 2 for really dirty air.  This not used in 2-moment cloud water
 !.. scheme and nu_c used instead and varies from 2 to 15 (integer-only).
-      !mu_c = MIN(15., (1000.E6/Nt_c + 2.))
       mu_c_l = MIN(15., (1000.E6/Nt_c_l + 2.))
       mu_c_o = MIN(15., (1000.E6/Nt_c_o + 2.))
 
@@ -1428,7 +1424,6 @@ MODULE module_mp_thompson
          else
             lsml = lsm(i,j)
             do k = kts, kte
-               !nc1d(k) = Nt_c/rho(k)
                if(lsml == 0) then
                  nc1d(k) = Nt_c_o/rho(k)
                else
@@ -2021,6 +2016,7 @@ MODULE module_mp_thompson
       odt = 1./dt
       odts = 1./dtsave
       iexfrq = 1
+! transition of terminal velocity from cloud ice to snow
       av_i = av_s * D0s ** (bv_s - bv_i)
 
 !+---+-----------------------------------------------------------------+
@@ -2226,7 +2222,6 @@ MODULE module_mp_thompson
             endif
             nc(k) = MIN( DBLE(Nt_c_max), ccg(1,nu_c)*ocg2(nu_c)*rc(k)   &
                   / am_r*lamc**bm_r)
-            !if (.NOT. (is_aerosol_aware .or. merra2_aerosol_aware)) nc(k) = Nt_c
             if (.NOT. (is_aerosol_aware .or. merra2_aerosol_aware)) then
                if (lsml == 0) then
                  nc(k) = Nt_c_o

--- a/physics/mp_thompson.F90
+++ b/physics/mp_thompson.F90
@@ -9,7 +9,7 @@ module mp_thompson
       use machine, only : kind_phys
 
       use module_mp_thompson, only : thompson_init, mp_gt_driver, thompson_finalize, calc_effectRad
-      use module_mp_thompson, only : naIN0, naIN1, naCCN0, naCCN1, eps, Nt_c
+      use module_mp_thompson, only : naIN0, naIN1, naCCN0, naCCN1, eps, Nt_c_l, Nt_c_o
       use module_mp_thompson, only : re_qc_min, re_qc_max, re_qi_min, re_qi_max, re_qs_min, re_qs_max
 
       use module_mp_thompson_make_number_concentrations, only: make_IceNumber, make_DropletNumber, make_RainNumber
@@ -284,7 +284,7 @@ module mp_thompson
 
            ! Constant droplet concentration for single moment cloud water as in
            ! module_mp_thompson.F90, only needed for effective radii calculation
-           nc_local = Nt_c/rho
+           nc_local = Nt_c_l/rho
 
          end if
 
@@ -322,7 +322,8 @@ module mp_thompson
                               merra2_aerosol_aware, nc, nwfa, nifa,&
                               nwfa2d, nifa2d, aero_ind_fdb,        &
                               tgrs, prsl, phii, omega,             &
-                              sedi_semi, decfl, dtp, dt_inner,     & 
+                              sedi_semi, decfl, islmsk, dtp,       &
+                              dt_inner,                            &
                               first_time_step, istep, nsteps,      &
                               prcp, rain, graupel, ice, snow, sr,  &
                               refl_10cm, reset_dBZ, do_radar_ref,  &
@@ -370,6 +371,7 @@ module mp_thompson
          real(kind_phys),           intent(in   ) :: prsl(:,:)
          real(kind_phys),           intent(in   ) :: phii(:,:)
          real(kind_phys),           intent(in   ) :: omega(:,:)
+         integer,                   intent(in   ) :: islmsk(:)
          real(kind_phys),           intent(in   ) :: dtp
          logical,                   intent(in   ) :: first_time_step
          integer,                   intent(in   ) :: istep, nsteps
@@ -687,7 +689,7 @@ module mp_thompson
             call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
                               nc=nc, nwfa=nwfa, nifa=nifa, nwfa2d=nwfa2d, nifa2d=nifa2d,     &
                               tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep, dt_inner=dt_inner,  &
-                              sedi_semi=sedi_semi, decfl=decfl,                              &
+                              sedi_semi=sedi_semi, decfl=decfl, lsm=islmsk,                  &
                               rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                               snownc=snow_mp, snowncv=delta_snow_mp,                         &
                               icenc=ice_mp, icencv=delta_ice_mp,                             &
@@ -727,7 +729,7 @@ module mp_thompson
          else
             call mp_gt_driver(qv=qv, qc=qc, qr=qr, qi=qi, qs=qs, qg=qg, ni=ni, nr=nr,        &
                               tt=tgrs, p=prsl, w=w, dz=dz, dt_in=dtstep, dt_inner=dt_inner,  &
-                              sedi_semi=sedi_semi, decfl=decfl,                              &
+                              sedi_semi=sedi_semi, decfl=decfl, lsm=islmsk,                  &
                               rainnc=rain_mp, rainncv=delta_rain_mp,                         &
                               snownc=snow_mp, snowncv=delta_snow_mp,                         &
                               icenc=ice_mp, icencv=delta_ice_mp,                             &

--- a/physics/mp_thompson.meta
+++ b/physics/mp_thompson.meta
@@ -510,6 +510,13 @@
   dimensions = ()
   type = integer
   intent = in
+[islmsk]
+  standard_name = sea_land_ice_mask
+  long_name = sea/land/ice mask (=0/1/2)
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = integer
+  intent = in
 [dtp]
   standard_name = timestep_for_physics
   long_name = physics timestep


### PR DESCRIPTION
This PR is created on behalf of @RuiyuSun to resolve Issue[#21](https://github.com/ufs-community/ccpp-physics/issues/21).

The purpose of this PR is to reduce the biases in the radiative fluxes, cloud cover, and surface temperature by modifying the Thompson microphysics scheme and its related part in the RRTMG(P) pre interstitial code. 

The PR includes:
1. MP changes to increase ice at high levels by using a larger maximum in the ice nucleation, smaller supersaturation requirement for the ice generation from %125 to %115; etc.
2. Cloud number concentration change to reduce the bias in surface downward shortwave radiative flux off the coastal regions including the SEP. Change was made in the Thompson MP, RRTMG, and RRTMGP source files.
3. Changes of threshold values in cloud cover calculation to early values to reduce cloud cover.

Another modification included in the following testing but not included in this PR is: 
  _The convective cloud condensate is used in the radiative flux calculation._
This modification is included in PR[#9](https://github.com/ufs-community/ccpp-physics/pull/9).

The testing results based on P8C is here.
[Copy of Coupled experiments based on P8C Evaluation_GFS_p8cctl_p8c15_p8c15cnvwinrad (1).pptx](https://github.com/ufs-community/ccpp-physics/files/9913542/Copy.of.Coupled.experiments.based.on.P8C.Evaluation_GFS_p8cctl_p8c15_p8c15cnvwinrad.1.pptx)
The testing results based on GFSv17 is here.
[GFSv17_highresol_cnvwinradiation_202007_202008 [Autosaved].pptx](https://github.com/ufs-community/ccpp-physics/files/9913538/GFSv17_highresol_cnvwinradiation_202007_202008.Autosaved.pptx)
