### PR TITLE
Ufs/dev ugwp improvements

### DIFF
--- a/physics/cires_ugwp.F90
+++ b/physics/cires_ugwp.F90
@@ -195,11 +195,13 @@ contains
 ! \section det_cires_ugwp CIRES UGWP V0 Scheme Detailed Algorithm
      subroutine cires_ugwp_run(do_ugwp, me,  master, im,  levs, ntrac, dtp, kdt, lonr, &
          oro, oro_uf, hprime, nmtvr, oc, theta, sigma, gamma, elvmax, clx, oa4,        &
-         do_tofd, ldiag_ugwp, cdmbgwd, xlat, xlat_d, sinlat, coslat, area,             &
-         ugrs, vgrs, tgrs, qgrs, prsi, prsl, prslk, phii, phil,                        &
+         do_tofd, ldiag_ugwp, cdmbgwd, xlat, xlat_d, sinlat, coslat,                   &
+         area, ugrs, vgrs, tgrs, qgrs, prsi, prsl, prslk, phii, phil,                  &
          del, kpbl, dusfcg, dvsfcg, gw_dudt, gw_dvdt, gw_dtdt, gw_kdis,                &
          tau_tofd, tau_mtb, tau_ogw, tau_ngw, zmtb, zlwb, zogw,                        &
-         dudt_mtb,dudt_ogw, dudt_tms, du3dt_mtb, du3dt_ogw, du3dt_tms,                 &
+         dusfc_ms, dvsfc_ms, dusfc_bl, dvsfc_bl,                                       &
+         dudt_ogw, dtauy2d_ms, dtaux2d_bl, dtauy2d_bl,                                 &
+         dudt_mtb, dudt_tms, du3dt_mtb, du3dt_ogw, du3dt_tms,                          &
          dudt, dvdt, dtdt, rdxzb, con_g, con_pi, con_cp, con_rd, con_rv, con_fvirt,    &
          con_omega, rain, ntke, q_tke, dqdt_tke, lprnt, ipr,                           &
          dtend, dtidx, index_of_x_wind, index_of_y_wind, index_of_temperature,         &
@@ -228,6 +230,9 @@ contains
     real(kind=kind_phys),    intent(out), dimension(:)      :: tau_mtb, tau_ogw, tau_tofd, tau_ngw
     real(kind=kind_phys),    intent(out), dimension(:, :):: gw_dudt, gw_dvdt, gw_dtdt, gw_kdis
     real(kind=kind_phys),    intent(out), dimension(:, :):: dudt_mtb, dudt_ogw, dudt_tms
+    real(kind=kind_phys),    intent(out), dimension(:)    :: dusfc_ms, dvsfc_ms, dusfc_bl, dvsfc_bl
+    real(kind=kind_phys),    intent(out), dimension(:, :) :: dtauy2d_ms
+    real(kind=kind_phys),    intent(out), dimension(:, :) :: dtaux2d_bl, dtauy2d_bl
 
     ! dtend is only allocated if ldiag=.true.
     real(kind=kind_phys), optional, intent(inout)            :: dtend(:,:,:)
@@ -314,9 +319,11 @@ contains
                     ugrs, vgrs, tgrs, qgrs(:,:,1),                      &
                     kpbl, prsi, del, prsl, prslk, phii, phil, dtp, kdt, &
                     hprime, oc, oa4, clx, theta, sigma, gamma,          &
-                    elvmax, dusfcg, dvsfcg,                             &
+                    elvmax, dusfcg, dvsfcg, dudt_ogw, dtauy2d_ms,       &
+                    dtaux2d_bl, dtauy2d_bl, dusfc_ms, dvsfc_ms,         &
+                    dusfc_bl, dvsfc_bl,                                 &
                     con_g,  con_cp, con_rd, con_rv, lonr,               &
-                    nmtvr, cdmbgwd, me, lprnt, ipr, rdxzb,              &
+                    nmtvr, cdmbgwd, me, lprnt, ipr, rdxzb, ldiag_ugwp,  &
                     errmsg, errflg)
          if (errflg/=0) return
        endif

--- a/physics/cires_ugwp.meta
+++ b/physics/cires_ugwp.meta
@@ -645,16 +645,16 @@
   kind = kind_phys
   intent = out
 [dtaux2d_bl]
-  standard_name = tendency_of_x_momentum_due_to_blocking_drag
-  long_name = x momentum tendency from blocking drag
+  standard_name = tendency_of_x_wind_due_to_blocking_drag
+  long_name = x wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtauy2d_bl]
-  standard_name = tendency_of_y_momentum_due_to_blocking_drag
-  long_name = y momentum tendency from blocking drag
+  standard_name = tendency_of_y_wind_due_to_blocking_drag
+  long_name = y wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real

--- a/physics/cires_ugwp.meta
+++ b/physics/cires_ugwp.meta
@@ -596,17 +596,73 @@
   type = real
   kind = kind_phys
   intent = out
-[dudt_mtb]
-  standard_name = instantaneous_change_in_x_wind_due_to_mountain_blocking_drag
-  long_name = instantaneous change in x wind due to mountain blocking drag
-  units = m s-2
-  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+[dusfc_ms]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = integrated x momentum flux from mesoscale gwd
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[dvsfc_ms]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = integrated y momentum flux from mesoscale gwd
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[dusfc_bl]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_blocking_drag
+  long_name = integrated x momentum flux from blocking drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[dvsfc_bl]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_blocking_drag
+  long_name = integrated y momentum flux from blocking drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = out
 [dudt_ogw]
   standard_name = tendency_of_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = instantaneous change in x wind due to orographic gw drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[dtauy2d_ms]
+  standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = instantaneous change in y wind due to orographic gw drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[dtaux2d_bl]
+  standard_name = tendency_of_x_momentum_due_to_blocking_drag
+  long_name = x momentum tendency from blocking drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[dtauy2d_bl]
+  standard_name = tendency_of_y_momentum_due_to_blocking_drag
+  long_name = y momentum tendency from blocking drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[dudt_mtb]
+  standard_name = instantaneous_change_in_x_wind_due_to_mountain_blocking_drag
+  long_name = instantaneous change in x wind due to mountain blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -7,7 +7,7 @@
       contains
 
 !> \defgroup gfs_drag_suite_mod GSL drag_suite Module
-!> This module contains the CCPP-compliant GSL orographic gravity wave dray scheme.
+!> This module contains the CCPP-compliant GSL orographic gravity wave drag scheme.
 !> @{
       subroutine drag_suite_init(gwd_opt, errmsg, errflg)
 
@@ -29,7 +29,7 @@
       end if        
       end subroutine drag_suite_init
 
-!> \brief This subroutine includes orographic gravity wave drag,  mountain
+!> \brief This subroutine includes orographic gravity wave drag, mountain
 !! blocking, and form drag.
 !!
 !> The time tendencies of zonal and meridional wind are altered to
@@ -200,16 +200,17 @@
 !!  an independent process.  The next step is to test
 !!
 !> \section det_drag_suite GFS Orographic GWD Scheme Detailed Algorithm
+!> @{
    subroutine drag_suite_run(                                           &
-     &           IM,KM,dvdt,dudt,dtdt,U1,V1,T1,Q1,KPBL,                 &
+     &           IM,KM,ak,bk,dvdt,dudt,dtdt,U1,V1,T1,Q1,KPBL,           &
      &           PRSI,DEL,PRSL,PRSLK,PHII,PHIL,DELTIM,KDT,              &
      &           var,oc1,oa4,ol4,                                       &
      &           varss,oc1ss,oa4ss,ol4ss,                               &
      &           THETA,SIGMA,GAMMA,ELVMAX,                              &
-     &           dtaux2d_ls,dtauy2d_ls,dtaux2d_bl,dtauy2d_bl,           &
+     &           dtaux2d_ms,dtauy2d_ms,dtaux2d_bl,dtauy2d_bl,           &
      &           dtaux2d_ss,dtauy2d_ss,dtaux2d_fd,dtauy2d_fd,           &
      &           dusfc,dvsfc,                                           &
-     &           dusfc_ls,dvsfc_ls,dusfc_bl,dvsfc_bl,                   &
+     &           dusfc_ms,dvsfc_ms,dusfc_bl,dvsfc_bl,                   &
      &           dusfc_ss,dvsfc_ss,dusfc_fd,dvsfc_fd,                   &
      &           slmsk,br1,hpbl,                                        &
      &           g, cp, rd, rv, fv, pi, imx, cdmbgwd, me, master,       &
@@ -217,7 +218,7 @@
      &           do_gsl_drag_ls_bl, do_gsl_drag_ss, do_gsl_drag_tofd,   &
      &           dtend, dtidx, index_of_process_orographic_gwd,         &
      &           index_of_temperature, index_of_x_wind,                 &
-     &           index_of_y_wind, ldiag3d,                              &
+     &           index_of_y_wind, ldiag3d, ldiag_ugwp, ugwp_seq_update, & 
      &           spp_wts_gwd, spp_gwd, errmsg, errflg)
 
 !   ********************************************************************
@@ -248,7 +249,7 @@
 !                    topographic form drag of Beljaars et al. (2004, QJRMS)
 !           Activation of each component is done by specifying the integer-parameters
 !           (defined below) to 0: inactive or 1: active
-!                    gwd_opt_ls = 0 or 1: large-scale  
+!                    gwd_opt_ms = 0 or 1: mesoscale  
 !                    gwd_opt_bl = 0 or 1: blocking drag
 !                    gwd_opt_ss = 0 or 1: small-scale gravity wave drag
 !                    gwd_opt_fd = 0 or 1: topographic form drag
@@ -258,11 +259,11 @@
 !    2020-08-25  Michael Toy changed logic control for drag component selection
 !                    for CCPP.
 !                    Namelist options:
-!                    do_gsl_drag_ls_bl - logical flag for large-scale GWD + blocking
+!                    do_gsl_drag_ls_bl - logical flag for mesoscale GWD + blocking
 !                    do_gsl_drag_ss - logical flag for small-scale GWD
 !                    do_gsl_drag_tofd - logical flag for turbulent form drag
 !                    Compile-time options (same as before):
-!                    gwd_opt_ls = 0 or 1: large-scale GWD
+!                    gwd_opt_ms = 0 or 1: mesoscale GWD
 !                    gwd_opt_bl = 0 or 1: blocking drag
 !
 !  References:
@@ -320,6 +321,7 @@
    integer, intent(in) :: gwd_opt
    logical, intent(in) :: lprnt
    integer, intent(in) :: KPBL(:)
+   real(kind=kind_phys), intent(in) :: ak(:), bk(:)
    real(kind=kind_phys), intent(in) :: deltim, G, CP, RD, RV, cdmbgwd(:)
    real(kind=kind_phys), intent(inout) :: dtend(:,:,:)
    logical, intent(in) :: ldiag3d
@@ -366,23 +368,23 @@
 
 !SPP
    real(kind=kind_phys), dimension(im) :: var_stoch, varss_stoch, &
-                                       varmax_ss_stoch, varmax_fd_stoch
+                                       varmax_fd_stoch
    real(kind=kind_phys), intent(in) :: spp_wts_gwd(:,:)
    integer, intent(in) :: spp_gwd
 
    real(kind=kind_phys), dimension(im)              :: rstoch
 
 !Output:
-   real(kind=kind_phys), intent(out) ::                          &
+   real(kind=kind_phys), intent(inout) ::                        &
      &                      dusfc(:),   dvsfc(:)
 !Output (optional):
    real(kind=kind_phys), intent(out) ::                          &
-     &                      dusfc_ls(:),dvsfc_ls(:),             &
+     &                      dusfc_ms(:),dvsfc_ms(:),             &
      &                      dusfc_bl(:),dvsfc_bl(:),             &
      &                      dusfc_ss(:),dvsfc_ss(:),             &
      &                      dusfc_fd(:),dvsfc_fd(:)
    real(kind=kind_phys), intent(out) ::                          &
-     &         dtaux2d_ls(:,:),dtauy2d_ls(:,:),                  &
+     &         dtaux2d_ms(:,:),dtauy2d_ms(:,:),                  &
      &         dtaux2d_bl(:,:),dtauy2d_bl(:,:),                  &
      &         dtaux2d_ss(:,:),dtauy2d_ss(:,:),                  &
      &         dtaux2d_fd(:,:),dtauy2d_fd(:,:)
@@ -395,13 +397,25 @@
 ! Each component is tapered off automatically as a function of dx, so best to
 ! keep them activated (.true.).
       logical, intent(in) ::   &
-      do_gsl_drag_ls_bl,       & ! large-scale gravity wave drag and blocking
+      do_gsl_drag_ls_bl,       & ! mesoscale gravity wave drag and blocking
       do_gsl_drag_ss,          & ! small-scale gravity wave drag (Steeneveld et al. 2008)
       do_gsl_drag_tofd           ! form drag (Beljaars et al. 2004, QJRMS)
 
+! Flag for diagnostic outputs
+      logical, intent(in) :: ldiag_ugwp
+
+! Flag for sequential update of u and v between
+! LSGWD + BLOCKING and SSGWD + TOFD calculations
+      logical, intent(in) :: ugwp_seq_update
+
+! More variables for sequential updating of winds
+      ! Updated winds
+      real(kind=kind_phys), dimension(im,km) :: uwnd1, vwnd1
+      real(kind=kind_phys) :: tmp1, tmp2   ! temporary variables
+
 ! Additional flags
       integer, parameter ::    &
-      gwd_opt_ls      = 1,     & ! large-scale gravity wave drag
+      gwd_opt_ms      = 1,     & ! mesoscale gravity wave drag
       gwd_opt_bl      = 1,     & ! blocking drag
       gsd_diss_ht_opt = 0
 
@@ -409,15 +423,14 @@
 ! Small-scale GWD + turbulent form drag
    real(kind=kind_phys), parameter      :: dxmin_ss = 1000.,                     &
      &                     dxmax_ss = 12000.  ! min,max range of tapering (m)
-! Large-scale GWD + blocking
-   real(kind=kind_phys), parameter      :: dxmin_ls = 3000.,                     &
-     &                     dxmax_ls = 13000.  ! min,max range of tapering (m)
-   real(kind=kind_phys), dimension(im)  :: ss_taper, ls_taper ! small- and large-scale tapering factors (-)
+! Mesoscale GWD + blocking
+   real(kind=kind_phys), parameter      :: dxmin_ms = 3000.,                     &
+     &                     dxmax_ms = 13000.  ! min,max range of tapering (m)
+   real(kind=kind_phys), dimension(im)  :: ss_taper, ls_taper ! small- and meso-scale tapering factors (-)
 !
 ! Variables for limiting topographic standard deviation (var)
-   real(kind=kind_phys), parameter      :: varmax_ss = 50.,                      &
-                           varmax_fd = 150.,                     &
-                           beta_ss = 0.1,                        &
+   real(kind=kind_phys), parameter      :: varmax_ss = 50.,      &  ! varmax_ss not used
+                           varmax_fd = 500.,                     &
                            beta_fd = 0.2
    real(kind=kind_phys)                 :: var_temp, var_temp2
 
@@ -441,6 +454,8 @@
    real(kind=kind_phys), parameter       ::  frc     = 1.0
    real(kind=kind_phys), parameter       ::  ce      = 0.8
    real(kind=kind_phys), parameter       ::  cg      = 0.5
+   real(kind=kind_phys), parameter       ::  pref    = 1000.0e+2 ! ref. press. for sigma press. calc.
+   real(kind=kind_phys), parameter       ::  rlolev  = 500.0e+2  ! max press lvl for dtfac
    integer,parameter    ::  kpblmin = 2
 
 !
@@ -457,6 +472,9 @@
 !
    logical              ::  ldrag(im),icrilv(im),                 &
                             flag(im),kloop1(im)
+   logical              ::  prop_test
+!
+   real(kind=kind_phys) ::  onebgrcs
 !
    real(kind=kind_phys) ::  taub(im),taup(im,km+1),               &
                             xn(im),yn(im),                        &
@@ -469,7 +487,7 @@
                             brvf(im),xlinv(im),                   &
                             delks(im),delks1(im),                 &
                             bnv2(im,km),usqj(im,km),              &
-                            taud_ls(im,km),taud_bl(im,km),        &
+                            taud_ms(im,km),taud_bl(im,km),        &
                             ro(im,km),                            &
                             vtk(im,km),vtj(im,km),                &
                             zlowtop(im),velco(im,km-1),           &
@@ -523,6 +541,12 @@
       Tdtend = dtidx(index_of_temperature,index_of_process_orographic_gwd)
    endif
 
+
+   ! Initialize winds for sequential updating
+   ! NOTE: These will only be updated if ugwp_seq_update == .true.
+   uwnd1(:,:) = u1(:,:)
+   vwnd1(:,:) = v1(:,:)
+
 !--------------------------------------------------------------------
 ! SCALE-ADPTIVE PARAMETER FROM GFS GWD SCHEME
 !--------------------------------------------------------------------
@@ -565,6 +589,7 @@
    lcap   = km
    lcapp1 = lcap + 1
    fdir   = mdir / (2.0*pi)
+   onebgrcs = 1./g*rcs
 
    do i=1,im
       if (slmsk(i)==1. .or. slmsk(i)==2.) then !sea/land/ice mask (=0/1/2) in FV3
@@ -577,14 +602,14 @@
 
 !--- calculate scale-aware tapering factors
 do i=1,im
-   if ( dx(i) .ge. dxmax_ls ) then
+   if ( dx(i) .ge. dxmax_ms ) then
       ls_taper(i) = 1.
    else
-      if ( dx(i) .le. dxmin_ls) then
+      if ( dx(i) .le. dxmin_ms) then
          ls_taper(i) = 0.
       else
-         ls_taper(i) = 0.5 * ( SIN(pi*(dx(i)-0.5*(dxmax_ls+dxmin_ls))/  &
-                                  (dxmax_ls-dxmin_ls)) + 1. )
+         ls_taper(i) = 0.5 * ( SIN(pi*(dx(i)-0.5*(dxmax_ms+dxmin_ms))/  &
+                                  (dxmax_ms-dxmin_ms)) + 1. )
       endif
    endif
 enddo
@@ -597,14 +622,12 @@ if ( spp_gwd==1 ) then
   do i = its,im
     var_stoch(i)   = var(i)   + var(i)*0.75*spp_wts_gwd(i,1)
     varss_stoch(i) = varss(i) + varss(i)*0.75*spp_wts_gwd(i,1)
-    varmax_ss_stoch(i) = varmax_ss + varmax_ss*0.75*spp_wts_gwd(i,1)
     varmax_fd_stoch(i) = varmax_fd + varmax_fd*0.75*spp_wts_gwd(i,1)
   enddo
 else
   do i = its,im
     var_stoch(i)   = var(i)
     varss_stoch(i) = varss(i)
-    varmax_ss_stoch(i) = varmax_ss
     varmax_fd_stoch(i) = varmax_fd
   enddo
 endif
@@ -659,43 +682,15 @@ enddo
        vtj(i,k)  = 0.0
        vtk(i,k)  = 0.0
        taup(i,k) = 0.0
-       taud_ls(i,k) = 0.0
+       taud_ms(i,k) = 0.0
        taud_bl(i,k) = 0.0
        dtaux2d(i,k) = 0.0
        dtauy2d(i,k) = 0.0
      enddo
    enddo
 !
-   if ( (gwd_opt == 33).or.(gwd_opt == 22) ) then
-     do i = its,im
-       dusfc_ls(i) = 0.0
-       dvsfc_ls(i) = 0.0
-       dusfc_bl(i) = 0.0
-       dvsfc_bl(i) = 0.0
-       dusfc_ss(i) = 0.0
-       dvsfc_ss(i) = 0.0
-       dusfc_fd(i) = 0.0
-       dvsfc_fd(i) = 0.0
-     enddo
-     do k = kts,km
-       do i = its,im
-         dtaux2d_ls(i,k)= 0.0
-         dtauy2d_ls(i,k)= 0.0
-         dtaux2d_bl(i,k)= 0.0
-         dtauy2d_bl(i,k)= 0.0
-         dtaux2d_ss(i,k)= 0.0
-         dtauy2d_ss(i,k)= 0.0
-         dtaux2d_fd(i,k)= 0.0
-         dtauy2d_fd(i,k)= 0.0
-       enddo
-     enddo
-   endif
-
    do i = its,im
-     taup(i,km+1) = 0.0
      xlinv(i)     = 1.0/xl
-     dusfc(i) = 0.0
-     dvsfc(i) = 0.0
    enddo
 !
 !  initialize array for flow-blocking drag
@@ -809,8 +804,9 @@ enddo
 !
 ! END INITIALIZATION; BEGIN GWD CALCULATIONS:
 !
+
 IF ( (do_gsl_drag_ls_bl).and.                            &
-     ((gwd_opt_ls .EQ. 1).or.(gwd_opt_bl .EQ. 1)) ) then
+     ((gwd_opt_ms .EQ. 1).or.(gwd_opt_bl .EQ. 1)) ) then
 
    do i=its,im
 
@@ -914,7 +910,7 @@ IF ( (do_gsl_drag_ls_bl).and.                            &
             xlinv(i) = coefm(i) * cleff
             tem      = fr(i) * fr(i) * oc1(i)
             gfobnv   = gmax * tem / ((tem + cg)*bnv(i))
-            if ( gwd_opt_ls .NE. 0 ) then
+            if ( gwd_opt_ms .NE. 0 ) then
                taub(i)  = xlinv(i) * roll(i) * ulow(i) * ulow(i)           &
                            * ulow(i) * gfobnv * efact
             else     ! We've gotten what we need for the blocking scheme
@@ -930,200 +926,15 @@ IF ( (do_gsl_drag_ls_bl).and.                            &
 
    enddo  ! do i=its,im
 
-ENDIF   ! (do_gsl_drag_ls_bl).and.((gwd_opt_ls .EQ. 1).or.(gwd_opt_bl .EQ. 1))
+ENDIF   ! (do_gsl_drag_ls_bl).and.((gwd_opt_ms .EQ. 1).or.(gwd_opt_bl .EQ. 1))
 
-!=========================================================
-! add small-scale wavedrag for stable boundary layer
-!=========================================================
-  XNBV=0.
-  tauwavex0=0.
-  tauwavey0=0.
-  density=1.2
-  utendwave=0.
-  vtendwave=0.
-!
-IF ( do_gsl_drag_ss ) THEN
 
-   do i=its,im
 
-      if ( ss_taper(i).GT.1.E-02 ) then
-   !
-   ! calculating potential temperature
-   !
-         do k = kts,km
-            thx(i,k) = t1(i,k)/prslk(i,k)
-         enddo
-   !
-         do k = kts,km
-            tvcon = (1.+fv*q1(i,k))
-            thvx(i,k) = thx(i,k)*tvcon
-         enddo
 
-         hpbl2 = hpbl(i)+10.
-         kpbl2 = kpbl(i)
-         !kvar = MIN(kpbl, k-level of var)
-         kvar = 1
-         do k=kts+1,MAX(kpbl(i),kts+1)
-!            IF (zl(i,k)>2.*var(i) .or. zl(i,k)>2*varmax) then
-            IF (zl(i,k)>300.) then
-               kpbl2 = k
-               IF (k == kpbl(i)) then
-                  hpbl2 = hpbl(i)+10.
-               ELSE
-                  hpbl2 = zl(i,k)+10.
-               ENDIF
-               exit
-            ENDIF
-         enddo
-         if((xland(i)-1.5).le.0. .and. 2.*varss_stoch(i).le.hpbl(i))then
-            if(br1(i).gt.0. .and. thvx(i,kpbl2)-thvx(i,kts) > 0.)then
-              ! Modify xlinv to represent wave number of "typical" small-scale topography 
-!              cleff_ss    = 3. * max(dx(i),cleff_ss)
-!              cleff_ss    = 10. * max(dxmax_ss,cleff_ss)
-!               cleff_ss    = 0.1 * 12000.
-              xlinv(i) = 0.001*pi   ! 2km horizontal wavelength
-              !govrth(i)=g/(0.5*(thvx(i,kpbl(i))+thvx(i,kts)))
-              govrth(i)=g/(0.5*(thvx(i,kpbl2)+thvx(i,kts)))
-              !XNBV=sqrt(govrth(i)*(thvx(i,kpbl(i))-thvx(i,kts))/hpbl(i))
-              XNBV=sqrt(govrth(i)*(thvx(i,kpbl2)-thvx(i,kts))/hpbl2)
-!
-              !if(abs(XNBV/u1(i,kpbl(i))).gt.xlinv(i))then
-              if(abs(XNBV/u1(i,kpbl2)).gt.xlinv(i))then
-                !tauwavex0=0.5*XNBV*xlinv(i)*(2*MIN(varss(i),75.))**2*ro(i,kts)*u1(i,kpbl(i))
-                !tauwavex0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*u1(i,kpbl2)
-                !tauwavex0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*u1(i,3)
-                ! Remove limit on varss_stoch
-                var_temp = varss_stoch(i)
-                ! Note:  This is a semi-implicit treatment of the time differencing
-                var_temp2 = 0.5*XNBV*xlinv(i)*(2.*var_temp)**2*ro(i,kvar)  ! this is greater than zero
-                tauwavex0=var_temp2*u1(i,kvar)/(1.+var_temp2*deltim)
-                tauwavex0=tauwavex0*ss_taper(i)
-              else
-                tauwavex0=0.
-              endif
-!
-              !if(abs(XNBV/v1(i,kpbl(i))).gt.xlinv(i))then
-              if(abs(XNBV/v1(i,kpbl2)).gt.xlinv(i))then
-                !tauwavey0=0.5*XNBV*xlinv(i)*(2*MIN(varss(i),75.))**2*ro(i,kts)*v1(i,kpbl(i))
-                !tauwavey0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*v1(i,kpbl2)
-                !tauwavey0=0.5*XNBV*xlinv(i)*(2.*MIN(varss(i),40.))**2*ro(i,kts)*v1(i,3)
-                ! Remove limit on varss_stoch
-                var_temp = varss_stoch(i)
-                ! Note:  This is a semi-implicit treatment of the time differencing
-                var_temp2 = 0.5*XNBV*xlinv(i)*(2.*var_temp)**2*ro(i,kvar)  ! this is greater than zero
-                tauwavey0=var_temp2*v1(i,kvar)/(1.+var_temp2*deltim)
-                tauwavey0=tauwavey0*ss_taper(i)
-              else
-                tauwavey0=0.
-              endif
-
-              do k=kts,kpbl(i) !MIN(kpbl2+1,km-1)
-!original
-                !utendwave(i,k)=-1.*tauwavex0*2.*max((1.-zl(i,k)/hpbl(i)),0.)/hpbl(i)
-                !vtendwave(i,k)=-1.*tauwavey0*2.*max((1.-zl(i,k)/hpbl(i)),0.)/hpbl(i)
-!new
-                utendwave(i,k)=-1.*tauwavex0*2.*max((1.-zl(i,k)/hpbl2),0.)/hpbl2
-                vtendwave(i,k)=-1.*tauwavey0*2.*max((1.-zl(i,k)/hpbl2),0.)/hpbl2
-!mod-to be used in HRRRv3/RAPv4
-                !utendwave(i,k)=-1.*tauwavex0 * max((1.-zl(i,k)/hpbl2),0.)**2
-                !vtendwave(i,k)=-1.*tauwavey0 * max((1.-zl(i,k)/hpbl2),0.)**2
-              enddo
-            endif
-         endif
-
-         do k = kts,km
-            dudt(i,k)  = dudt(i,k) + utendwave(i,k)
-            dvdt(i,k)  = dvdt(i,k) + vtendwave(i,k)
-            dusfc(i)   = dusfc(i) + utendwave(i,k) * del(i,k)
-            dvsfc(i)   = dvsfc(i) + vtendwave(i,k) * del(i,k)
-         enddo
-         if(udtend>0) then
-            dtend(i,kts:km,udtend) = dtend(i,kts:km,udtend) + utendwave(i,kts:km)*deltim
-         endif
-         if(vdtend>0) then
-            dtend(i,kts:km,vdtend) = dtend(i,kts:km,vdtend) + vtendwave(i,kts:km)*deltim
-         endif
-         if ( (gwd_opt == 33).or.(gwd_opt == 22) ) then
-            do k = kts,km
-               dusfc_ss(i) = dusfc_ss(i) + utendwave(i,k) * del(i,k)
-               dvsfc_ss(i) = dvsfc_ss(i) + vtendwave(i,k) * del(i,k)
-               dtaux2d_ss(i,k) = utendwave(i,k)
-               dtauy2d_ss(i,k) = vtendwave(i,k)
-            enddo
-         endif
-
-      endif  ! if (ss_taper(i).GT.1.E-02)
-
-   enddo  ! i=its,im
-
-ENDIF  ! if (do_gsl_drag_ss)
-
-!================================================================
-! Topographic Form Drag from Beljaars et al. (2004, QJRMS, equ. 16):
-!================================================================
-IF ( do_gsl_drag_tofd ) THEN
-
-   do i=its,im
-
-      if ( ss_taper(i).GT.1.E-02 ) then
-
-         utendform=0.
-         vtendform=0.
-
-         IF ((xland(i)-1.5) .le. 0.) then
-            !(IH*kflt**n1)**-1 = (0.00102*0.00035**-1.9)**-1 = 0.00026615161
-            ! Remove limit on varss_stoch
-            var_temp = varss_stoch(i)
-            !var_temp = MIN(var_temp, 250.)
-            a1=0.00026615161*var_temp**2
-!           a1=0.00026615161*MIN(varss(i),varmax)**2
-!           a1=0.00026615161*(0.5*varss(i))**2
-           ! k1**(n1-n2) = 0.003**(-1.9 - -2.8) = 0.003**0.9 = 0.005363
-            a2=a1*0.005363
-            ! Beljaars H_efold
-            H_efold = 1500.
-            DO k=kts,km
-               wsp=SQRT(u1(i,k)**2 + v1(i,k)**2)
-               ! alpha*beta*Cmd*Ccorr*2.109 = 12.*1.*0.005*0.6*2.109 = 0.0759
-               var_temp = 0.0759*EXP(-(zl(i,k)/H_efold)**1.5)*a2*          &
-                                 zl(i,k)**(-1.2)*ss_taper(i) ! this is greater than zero
-               !  Note:  This is a semi-implicit treatment of the time differencing
-               !  per Beljaars et al. (2004, QJRMS)
-               utendform(i,k) = - var_temp*wsp*u1(i,k)/(1. + var_temp*deltim*wsp)
-               vtendform(i,k) = - var_temp*wsp*v1(i,k)/(1. + var_temp*deltim*wsp)
-               !IF(zl(i,k) > 4000.) exit
-            ENDDO
-         ENDIF
-
-         do k = kts,km
-            dudt(i,k)  = dudt(i,k) + utendform(i,k)
-            dvdt(i,k)  = dvdt(i,k) + vtendform(i,k)
-            dusfc(i)   = dusfc(i) + utendform(i,k) * del(i,k)
-            dvsfc(i)   = dvsfc(i) + vtendform(i,k) * del(i,k)
-         enddo
-         if(udtend>0) then
-            dtend(i,kts:km,udtend) = dtend(i,kts:km,udtend) + utendform(i,kts:km)*deltim
-         endif
-         if(vdtend>0) then
-            dtend(i,kts:km,vdtend) = dtend(i,kts:km,vdtend) + vtendform(i,kts:km)*deltim
-         endif
-         if ( (gwd_opt == 33).or.(gwd_opt == 22) ) then
-            do k = kts,km
-               dtaux2d_fd(i,k) = utendform(i,k)
-               dtauy2d_fd(i,k) = vtendform(i,k)
-               dusfc_fd(i) = dusfc_fd(i) + utendform(i,k) * del(i,k)
-               dvsfc_fd(i) = dvsfc_fd(i) + vtendform(i,k) * del(i,k)
-            enddo
-         endif
-
-      endif   ! if (ss_taper(i).GT.1.E-02)
-
-   enddo  ! i=its,im
-
-ENDIF  ! if (do_gsl_drag_tofd)
 !=======================================================
-! More for the large-scale gwd component
-IF ( (do_gsl_drag_ls_bl).and.(gwd_opt_ls .EQ. 1) ) THEN
+! Mesoscale GWD + blocking
+!=======================================================
+IF ( (do_gsl_drag_ls_bl).and.(gwd_opt_ms .EQ. 1) ) THEN
 
    do i=its,im
 
@@ -1188,7 +999,7 @@ IF ( (do_gsl_drag_ls_bl).and.(gwd_opt_ls .EQ. 1) ) THEN
 
    enddo  ! do i=its,im
 
-ENDIF  ! (do_gsl_drag_ls_bl).and.(gwd_opt_ls .EQ. 1)
+ENDIF  ! (do_gsl_drag_ls_bl).and.(gwd_opt_ms .EQ. 1)
 !===============================================================
 !COMPUTE BLOCKING COMPONENT                                     
 !===============================================================
@@ -1227,7 +1038,7 @@ IF ( (do_gsl_drag_ls_bl) .and. (gwd_opt_bl .EQ. 1) ) THEN
                cd = max(2.0-1.0/od(i),0.0)
                ! New cdmbgwd addition for GSL blocking drag
                taufb(i,kts) = cdmb * 0.5 * roll(i) * coefm(i) /            &
-                                 max(dxmax_ls,dxy(i))**2 * cd * dxyp(i) *  &
+                                 max(dxmax_ms,dxy(i))**2 * cd * dxyp(i) *  &
                                  olp(i) * zblk * ulow(i)**2
                tautem = taufb(i,kts)/float(kblk-kts)
                do k = kts+1, kblk
@@ -1248,7 +1059,7 @@ IF ( (do_gsl_drag_ls_bl) .and. (gwd_opt_bl .EQ. 1) ) THEN
 ENDIF   ! IF ( (do_gsl_drag_ls_bl) .and. (gwd_opt_bl .EQ. 1) )
 !===========================================================
 IF ( (do_gsl_drag_ls_bl) .and.                                       &
-     (gwd_opt_ls .EQ. 1 .OR. gwd_opt_bl .EQ. 1) ) THEN 
+     (gwd_opt_ms .EQ. 1 .OR. gwd_opt_bl .EQ. 1) ) THEN 
 
    do i=its,im
 
@@ -1257,42 +1068,55 @@ IF ( (do_gsl_drag_ls_bl) .and.                                       &
 !
 !  calculate - (g)*d(tau)/d(pressure) and deceleration terms dtaux, dtauy
 !
+!  First, set taup (momentum flux) at model top equal to that of the layer
+!  interface just below the top, i.e., taup(km)
+!  The idea is to allow the momentum flux to go out the 'top'.  This
+!  ensures there is no GWD force at the top layer.
+!
+         taup(i,km+1) = taup(i,km)
          do k = kts,km
-            taud_ls(i,k) = 1. * (taup(i,k+1) - taup(i,k)) * csg / del(i,k)
+            taud_ms(i,k) = 1. * (taup(i,k+1) - taup(i,k)) * csg / del(i,k)
             taud_bl(i,k) = 1. * (taufb(i,k+1) - taufb(i,k)) * csg / del(i,k)
          enddo
 !
-!  limit de-acceleration (momentum deposition ) at top to 1/2 value
-!  the idea is some stuff must go out the 'top'
-         do klcap = lcap,km
-            taud_ls(i,klcap) = taud_ls(i,klcap) * factop
-            taud_bl(i,klcap) = taud_bl(i,klcap) * factop
-         enddo
 !
-!  if the gravity wave drag would force a critical line
-!  in the lower ksmm1 layers during the next deltim timestep,
-!  then only apply drag until that critical line is reached.
+!  if the gravity wave drag + blocking would force a critical line
+!  in the layers below 'sigma' pressure level = rlolev during the next deltim
+!  timestep, then only apply drag until that critical line is reached, i.e.,
+!  reduce drag to limit resulting wind components to zero
+!  Note: 'sigma' pressure = ak + pref*bk in units of Pa
 !
          do k = kts,kpblmax-1
-            if (k .le. kbl(i)) then
-               if ((taud_ls(i,k)+taud_bl(i,k)).ne.0.)                   &
+            if (ak(k)+pref*bk(k).ge.rlolev) then
+               if ((taud_ms(i,k)+taud_bl(i,k)).ne.0.)                   &
                   dtfac(i) = min(dtfac(i),abs(velco(i,k)                &
-                       /(deltim*rcs*(taud_ls(i,k)+taud_bl(i,k)))))
+                       /(deltim*rcs*(taud_ms(i,k)+taud_bl(i,k)))))
             endif
          enddo
 !
          do k = kts,km
-            taud_ls(i,k)  = taud_ls(i,k)*dtfac(i)* ls_taper(i) *(1.-rstoch(i))
+            taud_ms(i,k)  = taud_ms(i,k)*dtfac(i)* ls_taper(i) *(1.-rstoch(i))
             taud_bl(i,k)  = taud_bl(i,k)*dtfac(i)* ls_taper(i) *(1.-rstoch(i))
 
-            dtaux  = taud_ls(i,k) * xn(i)
-            dtauy  = taud_ls(i,k) * yn(i)
+            dtaux  = taud_ms(i,k) * xn(i)
+            dtauy  = taud_ms(i,k) * yn(i)
             dtauxb = taud_bl(i,k) * xn(i)
             dtauyb = taud_bl(i,k) * yn(i)
 
-            !add blocking and large-scale contributions to tendencies 
-            dudt(i,k)  = dtaux + dtauxb + dudt(i,k)
-            dvdt(i,k)  = dtauy + dtauyb + dvdt(i,k)
+            !add blocking and mesoscale contributions to tendencies 
+            tmp1 = dtaux + dtauxb
+            tmp2 = dtauy + dtauyb
+            dudt(i,k)  = tmp1 + dudt(i,k)
+            dvdt(i,k)  = tmp2 + dvdt(i,k)
+
+            ! Update winds if sequential updating is selected
+            ! and SSGWD and TOFD will be calculated
+            ! Note:  uwnd1 and vwnd1 replace u1 and u2,respectively,
+            ! for the SSGWD and TOFD calculations
+            if ( ugwp_seq_update .and. (do_gsl_drag_ss.or.do_gsl_drag_tofd) ) then
+               uwnd1(i,k) = uwnd1(i,k) + tmp1*deltim
+               vwnd1(i,k) = vwnd1(i,k) + tmp2*deltim
+            endif
 
             if ( gsd_diss_ht_opt .EQ. 1 ) then
                ! Calculate dissipation heating
@@ -1308,35 +1132,31 @@ IF ( (do_gsl_drag_ls_bl) .and.                                       &
                endif
             endif
 
-            dusfc(i)   = dusfc(i) + taud_ls(i,k)*xn(i)*del(i,k) +       &
-                                    taud_bl(i,k)*xn(i)*del(i,k)
-            dvsfc(i)   = dvsfc(i) + taud_ls(i,k)*yn(i)*del(i,k) +       &
-                                    taud_bl(i,k)*yn(i)*del(i,k)
+            dusfc(i) = dusfc(i) - onebgrcs * ( taud_ms(i,k)*xn(i)*del(i,k) + &
+                                    taud_bl(i,k)*xn(i)*del(i,k) )
+            dvsfc(i) = dvsfc(i) - onebgrcs * ( taud_ms(i,k)*yn(i)*del(i,k) + &
+                                    taud_bl(i,k)*yn(i)*del(i,k) )
             if(udtend>0) then
-               dtend(i,k,udtend) = dtend(i,k,udtend) + (taud_ls(i,k) *  &
+               dtend(i,k,udtend) = dtend(i,k,udtend) + (taud_ms(i,k) *  &
                     xn(i) + taud_bl(i,k) * xn(i)) * deltim
             endif
             if(vdtend>0) then
-               dtend(i,k,vdtend) = dtend(i,k,vdtend) + (taud_ls(i,k) *  &
+               dtend(i,k,vdtend) = dtend(i,k,vdtend) + (taud_ms(i,k) *  &
                     yn(i) + taud_bl(i,k) * yn(i)) * deltim
             endif
 
          enddo
 
-         !  Finalize dusfc and dvsfc diagnostics
-         dusfc(i) = (-1./g*rcs) * dusfc(i)
-         dvsfc(i) = (-1./g*rcs) * dvsfc(i)
-
-         if ( (gwd_opt == 33).or.(gwd_opt == 22) ) then
+         if ( ldiag_ugwp ) then
             do k = kts,km
-               dtaux2d_ls(i,k) = taud_ls(i,k) * xn(i)
-               dtauy2d_ls(i,k) = taud_ls(i,k) * yn(i)
+               dtaux2d_ms(i,k) = taud_ms(i,k) * xn(i)
+               dtauy2d_ms(i,k) = taud_ms(i,k) * yn(i)
                dtaux2d_bl(i,k) = taud_bl(i,k) * xn(i)
                dtauy2d_bl(i,k) = taud_bl(i,k) * yn(i)
-               dusfc_ls(i)  = dusfc_ls(i) + dtaux2d_ls(i,k) * del(i,k)
-               dvsfc_ls(i)  = dvsfc_ls(i) + dtauy2d_ls(i,k) * del(i,k)
-               dusfc_bl(i)  = dusfc_bl(i) + dtaux2d_bl(i,k) * del(i,k)
-               dvsfc_bl(i)  = dvsfc_bl(i) + dtauy2d_bl(i,k) * del(i,k)
+               dusfc_ms(i)  = dusfc_ms(i) - onebgrcs * dtaux2d_ms(i,k) * del(i,k)
+               dvsfc_ms(i)  = dvsfc_ms(i) - onebgrcs * dtauy2d_ms(i,k) * del(i,k)
+               dusfc_bl(i)  = dusfc_bl(i) - onebgrcs * dtaux2d_bl(i,k) * del(i,k)
+               dvsfc_bl(i)  = dvsfc_bl(i) - onebgrcs * dtauy2d_bl(i,k) * del(i,k)
             enddo
          endif
 
@@ -1344,20 +1164,217 @@ IF ( (do_gsl_drag_ls_bl) .and.                                       &
 
    enddo   ! do i=its,im
 
-ENDIF  ! (do_gsl_drag_ls_bl).and.(gwd_opt_ls.EQ.1 .OR. gwd_opt_bl.EQ.1)
+ENDIF  ! (do_gsl_drag_ls_bl).and.(gwd_opt_ms.EQ.1 .OR. gwd_opt_bl.EQ.1)
 
-if ( (gwd_opt == 33).or.(gwd_opt == 22) ) then
-  !  Finalize dusfc and dvsfc diagnostics
-  do i = its,im
-    dusfc_ls(i) = (-1./g*rcs) * dusfc_ls(i)
-    dvsfc_ls(i) = (-1./g*rcs) * dvsfc_ls(i)
-    dusfc_bl(i) = (-1./g*rcs) * dusfc_bl(i)
-    dvsfc_bl(i) = (-1./g*rcs) * dvsfc_bl(i)
-    dusfc_ss(i) = (-1./g*rcs) * dusfc_ss(i)
-    dvsfc_ss(i) = (-1./g*rcs) * dvsfc_ss(i)
-    dusfc_fd(i) = (-1./g*rcs) * dusfc_fd(i)
-    dvsfc_fd(i) = (-1./g*rcs) * dvsfc_fd(i)
-  enddo
+
+!====================================================================
+! Calculate small-scale gravity wave drag for stable boundary layer
+!====================================================================
+  XNBV=0.
+  tauwavex0=0.
+  tauwavey0=0.
+  density=1.2
+  utendwave=0.
+  vtendwave=0.
+!
+IF ( do_gsl_drag_ss ) THEN
+
+   do i=its,im
+
+      if ( ss_taper(i).GT.1.E-02 ) then
+   !
+   ! calculating potential temperature
+   !
+         do k = kts,km
+            thx(i,k) = t1(i,k)/prslk(i,k)
+         enddo
+   !
+         do k = kts,km
+            tvcon = (1.+fv*q1(i,k))
+            thvx(i,k) = thx(i,k)*tvcon
+         enddo
+
+         hpbl2 = hpbl(i)+10.
+         kpbl2 = kpbl(i)
+         !kvar = MIN(kpbl, k-level of var)
+         kvar = 1
+         do k=kts+1,MAX(kpbl(i),kts+1)
+!            IF (zl(i,k)>2.*var(i) .or. zl(i,k)>2*varmax) then
+            IF (zl(i,k)>300.) then
+               kpbl2 = k
+               IF (k == kpbl(i)) then
+                  hpbl2 = hpbl(i)+10.
+               ELSE
+                  hpbl2 = zl(i,k)+10.
+               ENDIF
+               exit
+            ENDIF
+         enddo
+         if((xland(i)-1.5).le.0. .and. 2.*varss_stoch(i).le.hpbl(i))then
+            if(br1(i).gt.0. .and. thvx(i,kpbl2)-thvx(i,kts) > 0.)then
+              ! Modify xlinv to represent wave number of "typical" small-scale topography 
+!              cleff_ss    = 3. * max(dx(i),cleff_ss)
+!              cleff_ss    = 10. * max(dxmax_ss,cleff_ss)
+!               cleff_ss    = 0.1 * 12000.
+              xlinv(i) = 0.001*pi   ! 2km horizontal wavelength
+              !govrth(i)=g/(0.5*(thvx(i,kpbl(i))+thvx(i,kts)))
+              govrth(i)=g/(0.5*(thvx(i,kpbl2)+thvx(i,kts)))
+              !XNBV=sqrt(govrth(i)*(thvx(i,kpbl(i))-thvx(i,kts))/hpbl(i))
+              XNBV=sqrt(govrth(i)*(thvx(i,kpbl2)-thvx(i,kts))/hpbl2)
+!
+              ! check for possibility of vertical wave propagation
+              ! (avoids division by zero if uwnd1(i,kpbl2).eq.0.)
+              if (uwnd1(i,kpbl2).eq.0.) then
+                 prop_test = .true.
+              elseif (abs(XNBV/uwnd1(i,kpbl2)).gt.xlinv(i)) then
+                 prop_test = .true.
+              else
+                 prop_test = .false.
+              endif
+              if (prop_test) then
+                ! Remove limit on varss_stoch
+                var_temp = varss_stoch(i)
+                ! Note:  This is a semi-implicit treatment of the time differencing
+                var_temp2 = 0.5*XNBV*xlinv(i)*(2.*var_temp)**2*ro(i,kvar)  ! this is greater than zero
+                tauwavex0=var_temp2*uwnd1(i,kvar)/(1.+var_temp2*deltim)
+                tauwavex0=tauwavex0*ss_taper(i)
+              else
+                tauwavex0=0.
+              endif
+!
+              ! check for possibility of vertical wave propagation
+              ! (avoids division by zero if vwnd1(i,kpbl2).eq.0.)
+              if (vwnd1(i,kpbl2).eq.0.) then
+                 prop_test = .true.
+              elseif (abs(XNBV/vwnd1(i,kpbl2)).gt.xlinv(i)) then
+                 prop_test = .true.
+              else
+                 prop_test = .false.
+              endif
+              if (prop_test) then
+                ! Remove limit on varss_stoch
+                var_temp = varss_stoch(i)
+                ! Note:  This is a semi-implicit treatment of the time differencing
+                var_temp2 = 0.5*XNBV*xlinv(i)*(2.*var_temp)**2*ro(i,kvar)  ! this is greater than zero
+                tauwavey0=var_temp2*vwnd1(i,kvar)/(1.+var_temp2*deltim)
+                tauwavey0=tauwavey0*ss_taper(i)
+              else
+                tauwavey0=0.
+              endif
+
+              do k=kts,kpbl(i) !MIN(kpbl2+1,km-1)
+!original
+                !utendwave(i,k)=-1.*tauwavex0*2.*max((1.-zl(i,k)/hpbl(i)),0.)/hpbl(i)
+                !vtendwave(i,k)=-1.*tauwavey0*2.*max((1.-zl(i,k)/hpbl(i)),0.)/hpbl(i)
+!new
+                utendwave(i,k)=-1.*tauwavex0*2.*max((1.-zl(i,k)/hpbl2),0.)/hpbl2
+                vtendwave(i,k)=-1.*tauwavey0*2.*max((1.-zl(i,k)/hpbl2),0.)/hpbl2
+!mod-to be used in HRRRv3/RAPv4
+                !utendwave(i,k)=-1.*tauwavex0 * max((1.-zl(i,k)/hpbl2),0.)**2
+                !vtendwave(i,k)=-1.*tauwavey0 * max((1.-zl(i,k)/hpbl2),0.)**2
+              enddo
+            endif
+         endif
+
+         do k = kts,km
+            dudt(i,k)  = dudt(i,k) + utendwave(i,k)
+            dvdt(i,k)  = dvdt(i,k) + vtendwave(i,k)
+            dusfc(i)   = dusfc(i) - onebgrcs * utendwave(i,k) * del(i,k)
+            dvsfc(i)   = dvsfc(i) - onebgrcs * vtendwave(i,k) * del(i,k)
+         enddo
+         if(udtend>0) then
+            dtend(i,kts:km,udtend) = dtend(i,kts:km,udtend) + utendwave(i,kts:km)*deltim
+         endif
+         if(vdtend>0) then
+            dtend(i,kts:km,vdtend) = dtend(i,kts:km,vdtend) + vtendwave(i,kts:km)*deltim
+         endif
+         if ( ldiag_ugwp ) then
+            do k = kts,km
+               dusfc_ss(i) = dusfc_ss(i) + utendwave(i,k) * del(i,k)
+               dvsfc_ss(i) = dvsfc_ss(i) + vtendwave(i,k) * del(i,k)
+               dtaux2d_ss(i,k) = utendwave(i,k)
+               dtauy2d_ss(i,k) = vtendwave(i,k)
+            enddo
+         endif
+
+      endif  ! if (ss_taper(i).GT.1.E-02)
+
+   enddo  ! i=its,im
+
+ENDIF  ! if (do_gsl_drag_ss)
+
+
+!===================================================================
+! Topographic Form Drag from Beljaars et al. (2004, QJRMS, equ. 16):
+!===================================================================
+IF ( do_gsl_drag_tofd ) THEN
+
+   do i=its,im
+
+      if ( ss_taper(i).GT.1.E-02 ) then
+
+         utendform=0.
+         vtendform=0.
+
+         IF ((xland(i)-1.5) .le. 0.) then
+            !(IH*kflt**n1)**-1 = (0.00102*0.00035**-1.9)**-1 = 0.00026615161
+            var_temp = MIN(varss_stoch(i),varmax_fd_stoch(i)) +                &
+                       MAX(0.,beta_fd*(varss_stoch(i)-varmax_fd_stoch(i)))
+            a1=0.00026615161*var_temp**2
+!           a1=0.00026615161*MIN(varss(i),varmax)**2
+!           a1=0.00026615161*(0.5*varss(i))**2
+           ! k1**(n1-n2) = 0.003**(-1.9 - -2.8) = 0.003**0.9 = 0.005363
+            a2=a1*0.005363
+            ! Beljaars H_efold
+            H_efold = 1500.
+            DO k=kts,km
+               wsp=SQRT(uwnd1(i,k)**2 + vwnd1(i,k)**2)
+               ! alpha*beta*Cmd*Ccorr*2.109 = 12.*1.*0.005*0.6*2.109 = 0.0759
+               var_temp = 0.0759*EXP(-(zl(i,k)/H_efold)**1.5)*a2*          &
+                                 zl(i,k)**(-1.2)*ss_taper(i) ! this is greater than zero
+               !  Note:  This is a semi-implicit treatment of the time differencing
+               !  per Beljaars et al. (2004, QJRMS)
+               utendform(i,k) = - var_temp*wsp*uwnd1(i,k)/(1. + var_temp*deltim*wsp)
+               vtendform(i,k) = - var_temp*wsp*vwnd1(i,k)/(1. + var_temp*deltim*wsp)
+               !IF(zl(i,k) > 4000.) exit
+            ENDDO
+         ENDIF
+
+         do k = kts,km
+            dudt(i,k)  = dudt(i,k) + utendform(i,k)
+            dvdt(i,k)  = dvdt(i,k) + vtendform(i,k)
+            dusfc(i)   = dusfc(i) - onebgrcs * utendform(i,k) * del(i,k)
+            dvsfc(i)   = dvsfc(i) - onebgrcs * vtendform(i,k) * del(i,k)
+         enddo
+         if(udtend>0) then
+            dtend(i,kts:km,udtend) = dtend(i,kts:km,udtend) + utendform(i,kts:km)*deltim
+         endif
+         if(vdtend>0) then
+            dtend(i,kts:km,vdtend) = dtend(i,kts:km,vdtend) + vtendform(i,kts:km)*deltim
+         endif
+         if ( ldiag_ugwp ) then
+            do k = kts,km
+               dtaux2d_fd(i,k) = utendform(i,k)
+               dtauy2d_fd(i,k) = vtendform(i,k)
+               dusfc_fd(i) = dusfc_fd(i) + utendform(i,k) * del(i,k)
+               dvsfc_fd(i) = dvsfc_fd(i) + vtendform(i,k) * del(i,k)
+            enddo
+         endif
+
+      endif   ! if (ss_taper(i).GT.1.E-02)
+
+   enddo  ! i=its,im
+
+ENDIF  ! if (do_gsl_drag_tofd)
+
+
+
+if ( ldiag_ugwp ) then
+   !  Finalize dusfc and dvsfc diagnostics for gsl small-scale drag components
+   dusfc_ss(:) = -onebgrcs * dusfc_ss(:)
+   dvsfc_ss(:) = -onebgrcs * dvsfc_ss(:)
+   dusfc_fd(:) = -onebgrcs * dusfc_fd(:)
+   dvsfc_fd(:) = -onebgrcs * dvsfc_fd(:)
 endif
 !
    return

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -540,8 +540,12 @@
    endif
 
 
-   ! Initialize winds for sequential updating
-   ! NOTE: These will only be updated if ugwp_seq_update == .true.
+   ! Initialize winds for sequential updating.
+   ! These are for optional sequential updating of the wind between the
+   ! LSGWD+BLOCKING and SSGWD+TOFD steps.  They are placeholders
+   ! for the u1,v1 winds that are updated within the scheme if
+   ! ugwp_seq_update == T, otherwise, they retain the values
+   ! passed in to the subroutine.
    uwnd1(:,:) = u1(:,:)
    vwnd1(:,:) = v1(:,:)
 

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -454,8 +454,7 @@
    real(kind=kind_phys), parameter       ::  frc     = 1.0
    real(kind=kind_phys), parameter       ::  ce      = 0.8
    real(kind=kind_phys), parameter       ::  cg      = 0.5
-   real(kind=kind_phys), parameter       ::  pref    = 1000.0e+2 ! ref. press. for sigma press. calc.
-   real(kind=kind_phys), parameter       ::  rlolev  = 500.0e+2  ! max press lvl for dtfac
+   real(kind=kind_phys), parameter       ::  sgmalolev  = 0.5  ! max sigma lvl for dtfac
    integer,parameter    ::  kpblmin = 2
 
 !
@@ -1081,16 +1080,18 @@ IF ( (do_gsl_drag_ls_bl) .and.                                       &
 !
 !
 !  if the gravity wave drag + blocking would force a critical line
-!  in the layers below 'sigma' pressure level = rlolev during the next deltim
+!  in the layers below pressure-based 'sigma' level = sgmalolev during the next deltim
 !  timestep, then only apply drag until that critical line is reached, i.e.,
 !  reduce drag to limit resulting wind components to zero
-!  Note: 'sigma' pressure = ak + pref*bk in units of Pa
+!  Note: 'sigma' = prsi(k)/prsi(k=1), where prsi(k=1) is the surface pressure
 !
          do k = kts,kpblmax-1
-            if (ak(k)+pref*bk(k).ge.rlolev) then
+            if (prsi(i,k).ge.sgmalolev*prsi(i,1)) then
                if ((taud_ms(i,k)+taud_bl(i,k)).ne.0.)                   &
                   dtfac(i) = min(dtfac(i),abs(velco(i,k)                &
                        /(deltim*rcs*(taud_ms(i,k)+taud_bl(i,k)))))
+            else
+               exit
             endif
          enddo
 !

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -202,7 +202,7 @@
 !> \section det_drag_suite GFS Orographic GWD Scheme Detailed Algorithm
 !> @{
    subroutine drag_suite_run(                                           &
-     &           IM,KM,ak,bk,dvdt,dudt,dtdt,U1,V1,T1,Q1,KPBL,           &
+     &           IM,KM,dvdt,dudt,dtdt,U1,V1,T1,Q1,KPBL,                 &
      &           PRSI,DEL,PRSL,PRSLK,PHII,PHIL,DELTIM,KDT,              &
      &           var,oc1,oa4,ol4,                                       &
      &           varss,oc1ss,oa4ss,ol4ss,                               &
@@ -321,7 +321,6 @@
    integer, intent(in) :: gwd_opt
    logical, intent(in) :: lprnt
    integer, intent(in) :: KPBL(:)
-   real(kind=kind_phys), intent(in) :: ak(:), bk(:)
    real(kind=kind_phys), intent(in) :: deltim, G, CP, RD, RV, cdmbgwd(:)
    real(kind=kind_phys), intent(inout) :: dtend(:,:,:)
    logical, intent(in) :: ldiag3d

--- a/physics/drag_suite.meta
+++ b/physics/drag_suite.meta
@@ -569,21 +569,21 @@
   type = integer
   intent = in
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  standard_name = do_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
   long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_gsl_drag_ss]
-  standard_name = flag_for_gsl_drag_suite_small_scale_orographic_drag
+  standard_name = do_gsl_drag_suite_small_scale_orographic_drag
   long_name = flag to activate GSL drag suite - small-scale GWD
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_gsl_drag_tofd]
-  standard_name = flag_for_gsl_drag_suite_turbulent_orographic_form_drag
+  standard_name = do_gsl_drag_suite_turbulent_orographic_form_drag
   long_name = flag to activate GSL drag suite - turb orog form drag
   units = flag
   dimensions = ()
@@ -648,7 +648,7 @@
   type = logical
   intent = in
 [ugwp_seq_update]
-  standard_name = ugwp_sequential_update_flag
+  standard_name = do_ugwp_sequential_update
   long_name = flag for ugwp sequential update
   units = flag
   dimensions = ()

--- a/physics/drag_suite.meta
+++ b/physics/drag_suite.meta
@@ -48,22 +48,6 @@
   dimensions = ()
   type = integer
   intent = in
-[ak]
-  standard_name = sigma_pressure_hybrid_coordinate_a_coefficient
-  long_name = a parameter for sigma pressure level calculations
-  units = Pa
-  dimensions = (vertical_interface_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
-[bk]
-  standard_name = sigma_pressure_hybrid_coordinate_b_coefficient
-  long_name = b parameter for sigma pressure level calculations
-  units = none
-  dimensions = (vertical_interface_dimension)
-  type = real
-  kind = kind_phys
-  intent = in
 [dvdt]
   standard_name = process_split_cumulative_tendency_of_y_wind
   long_name = meridional wind tendency due to model physics

--- a/physics/drag_suite.meta
+++ b/physics/drag_suite.meta
@@ -48,6 +48,22 @@
   dimensions = ()
   type = integer
   intent = in
+[ak]
+  standard_name = sigma_pressure_hybrid_coordinate_a_coefficient
+  long_name = a parameter for sigma pressure level calculations
+  units = Pa
+  dimensions = (vertical_interface_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[bk]
+  standard_name = sigma_pressure_hybrid_coordinate_b_coefficient
+  long_name = b parameter for sigma pressure level calculations
+  units = none
+  dimensions = (vertical_interface_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
 [dvdt]
   standard_name = process_split_cumulative_tendency_of_y_wind
   long_name = meridional wind tendency due to model physics
@@ -270,17 +286,17 @@
   type = real
   kind = kind_phys
   intent = in
-[dtaux2d_ls]
+[dtaux2d_ms]
   standard_name = tendency_of_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = x momentum tendency from large scale gwd
+  long_name = x momentum tendency from mesoscale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
-[dtauy2d_ls]
+[dtauy2d_ms]
   standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = y momentum tendency from large scale gwd
+  long_name = y momentum tendency from mesoscale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -341,7 +357,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [dvsfc]
   standard_name = instantaneous_y_stress_due_to_gravity_wave_drag
   long_name = meridional surface stress due to orographic gravity wave drag
@@ -349,18 +365,18 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
-[dusfc_ls]
+  intent = inout
+[dusfc_ms]
   standard_name = vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = integrated x momentum flux from large scale gwd
+  long_name = integrated x momentum flux from mesoscale gwd
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = out
-[dvsfc_ls]
+[dvsfc_ms]
   standard_name = vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = integrated y momentum flux from large scale gwd
+  long_name = integrated y momentum flux from mesoscale gwd
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
@@ -553,8 +569,8 @@
   type = integer
   intent = in
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_large_scale_orographic_and_blocking_drag
-  long_name = flag to activate GSL drag suite - large-scale GWD and blocking
+  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
@@ -620,6 +636,20 @@
 [ldiag3d]
   standard_name = flag_for_diagnostics_3D
   long_name = flag for 3d diagnostic fields
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[ldiag_ugwp]
+  standard_name = flag_for_unified_gravity_wave_physics_diagnostics
+  long_name = flag for CIRES UGWP Diagnostics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[ugwp_seq_update]
+  standard_name = ugwp_sequential_update_flag
+  long_name = flag for ugwp sequential update
   units = flag
   dimensions = ()
   type = logical

--- a/physics/drag_suite.meta
+++ b/physics/drag_suite.meta
@@ -288,7 +288,7 @@
   intent = in
 [dtaux2d_ms]
   standard_name = tendency_of_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = x momentum tendency from mesoscale gwd
+  long_name = x wind tendency from mesoscale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -296,55 +296,55 @@
   intent = out
 [dtauy2d_ms]
   standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = y momentum tendency from mesoscale gwd
+  long_name = y wind tendency from mesoscale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtaux2d_bl]
-  standard_name = tendency_of_x_momentum_due_to_blocking_drag
-  long_name = x momentum tendency from blocking drag
+  standard_name = tendency_of_x_wind_due_to_blocking_drag
+  long_name = x wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtauy2d_bl]
-  standard_name = tendency_of_y_momentum_due_to_blocking_drag
-  long_name = y momentum tendency from blocking drag
+  standard_name = tendency_of_y_wind_due_to_blocking_drag
+  long_name = y wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtaux2d_ss]
-  standard_name = tendency_of_x_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = x momentum tendency from small scale gwd
+  standard_name = tendency_of_x_wind_due_to_small_scale_gravity_wave_drag
+  long_name = x wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtauy2d_ss]
-  standard_name = tendency_of_y_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = y momentum tendency from small scale gwd
+  standard_name = tendency_of_y_wind_due_to_small_scale_gravity_wave_drag
+  long_name = y wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtaux2d_fd]
-  standard_name = tendency_of_x_momentum_due_to_form_drag
-  long_name = x momentum tendency from form drag
+  standard_name = tendency_of_x_wind_due_to_form_drag
+  long_name = x wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtauy2d_fd]
-  standard_name = tendency_of_y_momentum_due_to_form_drag
-  long_name = y momentum tendency from form drag
+  standard_name = tendency_of_y_wind_due_to_form_drag
+  long_name = y wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real

--- a/physics/gwdps.f
+++ b/physics/gwdps.f
@@ -1281,7 +1281,7 @@
 !     endif
 
       if (ldiag_ugwp) then
-         !  Finalize dusfc and dvsfc diagnostics for gsl drag components
+         !  Finalize dusfc and dvsfc diagnostics
          DO i = 1,npt
             j = ipt(i)
             dusfc_ms(j) = - onebg * dusfc_ms(j)

--- a/physics/gwdps.f
+++ b/physics/gwdps.f
@@ -315,11 +315,11 @@
      &                     THETA(:), SIGMA(:), GAMMA(:)
       real(kind=kind_phys), intent(inout) :: DUSFC(:), DVSFC(:),        &
      &                     RDXZB(:)
-      real(kind=kind_phys), intent(inout) :: dtaux2d_ms(IM,KM),         &
-     &                     dtauy2d_ms(IM,KM),dtaux2d_bl(IM,KM),         &
-     &                     dtauy2d_bl(IM,KM)
-      real(kind=kind_phys), intent(inout) :: dusfc_ms(IM), dvsfc_ms(IM), &
-     &                     dusfc_bl(IM), dvsfc_bl(IM)
+      real(kind=kind_phys), intent(inout) :: dtaux2d_ms(:,:),           &
+     &                     dtauy2d_ms(:,:), dtaux2d_bl(:,:),            &
+     &                     dtauy2d_bl(:,:)
+      real(kind=kind_phys), intent(inout) :: dusfc_ms(:), dvsfc_ms(:),  &
+     &                     dusfc_bl(:), dvsfc_bl(:)
       integer, intent(in) :: nmtvr
       logical, intent(in) :: lprnt
       logical, intent(in) :: ldiag_ugwp

--- a/physics/gwdps.f
+++ b/physics/gwdps.f
@@ -3,6 +3,7 @@
 !! drag and mountain blocking.
 
 !> This module contains the CCPP-compliant orographic gravity wave dray scheme.
+!> This version of gwdps is called from the unified_ugwp CCPP scheme
       module gwdps
 
       contains
@@ -194,8 +195,12 @@
      &           IM,KM,A,B,C,U1,V1,T1,Q1,KPBL,                          &
      &           PRSI,DEL,PRSL,PRSLK,PHII, PHIL,DELTIM,KDT,             &
      &           HPRIME,OC,OA4,CLX4,THETA,SIGMA,GAMMA,ELVMAX,           &
-     &           DUSFC,DVSFC,G, CP, RD, RV, IMX,                        &
-     &           nmtvr, cdmbgwd, me, lprnt, ipr, rdxzb, errmsg, errflg)
+     &           DUSFC,DVSFC,dtaux2d_ms,dtauy2d_ms,dtaux2d_bl,          &
+     &           dtauy2d_bl,dusfc_ms,dvsfc_ms,dusfc_bl,dvsfc_bl,        &
+     &           G, CP, RD, RV, IMX,                                    &
+     &           nmtvr, cdmbgwd, me, lprnt, ipr, rdxzb, ldiag_ugwp,     &
+     &           errmsg, errflg)
+
 !
 !   ********************************************************************
 ! ----->  I M P L E M E N T A T I O N    V E R S I O N   <----------
@@ -308,10 +313,16 @@
       real(kind=kind_phys), intent(inout) :: ELVMAX(:)
       real(kind=kind_phys), intent(in) ::                               &
      &                     THETA(:), SIGMA(:), GAMMA(:)
-      real(kind=kind_phys), intent(out) :: DUSFC(:), DVSFC(:),          &
+      real(kind=kind_phys), intent(inout) :: DUSFC(:), DVSFC(:),        &
      &                     RDXZB(:)
+      real(kind=kind_phys), intent(inout) :: dtaux2d_ms(IM,KM),         &
+     &                     dtauy2d_ms(IM,KM),dtaux2d_bl(IM,KM),         &
+     &                     dtauy2d_bl(IM,KM)
+      real(kind=kind_phys), intent(inout) :: dusfc_ms(IM), dvsfc_ms(IM), &
+     &                     dusfc_bl(IM), dvsfc_bl(IM)
       integer, intent(in) :: nmtvr
       logical, intent(in) :: lprnt
+      logical, intent(in) :: ldiag_ugwp
       character(len=*), intent(out) :: errmsg
       integer,          intent(out) :: errflg
 !
@@ -413,10 +424,6 @@
       cdmbo4 = 0.25 * cdmb
 !
       npr = 0
-      DO I = 1, IM
-        DUSFC(I) = 0.
-        DVSFC(I) = 0.
-      ENDDO
 !
       DO K = 1, KM
         DO I = 1, IM
@@ -1237,8 +1244,15 @@
 !    &                      dbim,idxzb(I),U1(J,K),V1(J,K),me
 
             tem1     = DBIM * DEL(J,K)
-            DUSFC(J) = DUSFC(J) - tem1 * U1(J,K)
-            DVSFC(J) = DVSFC(J) - tem1 * V1(J,K)
+            DUSFC(J) = DUSFC(J) + onebg * tem1 * U1(J,K)
+            DVSFC(J) = DVSFC(J) + onebg * tem1 * V1(J,K)
+            ! Output blocking tendencies if ldiag_ugwp=.true.
+            if (ldiag_ugwp) then
+               dtaux2d_bl(j,k) = - DBIM * U1(J,K)
+               dtauy2d_bl(j,k) = - DBIM * V1(J,K)
+               dusfc_bl(j) = dusfc_bl(j) + dtaux2d_bl(j,k) * del(j,k)
+               dvsfc_bl(j) = dvsfc_bl(j) + dtauy2d_bl(j,k) * del(j,k)
+            end if
           else                                         ! orographic GWD applied
                                                        ! ----------------------
             A(J,K)   = DTAUY + A(J,K)
@@ -1246,8 +1260,15 @@
             tem1     = U1(J,K) + DTAUX*DELTIM
             tem2     = V1(J,K) + DTAUY*DELTIM
             ENG1     = 0.5 * (tem1*tem1+tem2*tem2)
-            DUSFC(J) = DUSFC(J) + DTAUX * DEL(J,K)
-            DVSFC(J) = DVSFC(J) + DTAUY * DEL(J,K)
+            DUSFC(J) = DUSFC(J) - onebg * DTAUX * DEL(J,K)
+            DVSFC(J) = DVSFC(J) - onebg * DTAUY * DEL(J,K)
+            ! Output mesoscale GWD tendencies if ldiag_ugwp=.ture.
+            if (ldiag_ugwp) then
+               dtaux2d_ms(j,k) = DTAUX
+               dtauy2d_ms(j,k) = DTAUY
+               dusfc_ms(j) = dusfc_ms(j) + DTAUX * del(j,k)
+               dvsfc_ms(j) = dvsfc_ms(j) + DTAUY * del(j,k)
+            end if
           endif
           C(J,K) = C(J,K) + max(ENG0-ENG1,0.) * oneocpdt
         ENDDO
@@ -1259,12 +1280,16 @@
 !       print *,' DB=',DB(ipr,:)
 !     endif
 
-      DO I = 1,npt
-        J        = ipt(i)
-!       TEM      = (-1.E3/G)
-        DUSFC(J) = - onebg * DUSFC(J)
-        DVSFC(J) = - onebg * DVSFC(J)
-      ENDDO
+      if (ldiag_ugwp) then
+         !  Finalize dusfc and dvsfc diagnostics for gsl drag components
+         DO i = 1,npt
+            j = ipt(i)
+            dusfc_ms(j) = - onebg * dusfc_ms(j)
+            dvsfc_ms(j) = - onebg * dvsfc_ms(j)
+            dusfc_bl(j) = - onebg * dusfc_bl(j)
+            dvsfc_bl(j) = - onebg * dvsfc_bl(j)
+         ENDDO
+      end if
 !
 !    MONITOR FOR EXCESSIVE GRAVITY WAVE DRAG TENDENCIES IF NCNT>0
 !

--- a/physics/gwdps.meta
+++ b/physics/gwdps.meta
@@ -234,7 +234,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [dtauy2d_ms]
   standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = instantaneous change in y wind due to orographic gw drag
@@ -242,7 +242,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [dtaux2d_bl]
   standard_name = tendency_of_x_momentum_due_to_blocking_drag
   long_name = x momentum tendency from blocking drag
@@ -250,7 +250,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [dtauy2d_bl]
   standard_name = tendency_of_y_momentum_due_to_blocking_drag
   long_name = y momentum tendency from blocking drag
@@ -258,7 +258,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [dusfc_ms]
   standard_name = vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = integrated x momentum flux from mesoscale gwd
@@ -266,7 +266,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [dvsfc_ms]
   standard_name = vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = integrated y momentum flux from mesoscale gwd
@@ -274,7 +274,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [dusfc_bl]
   standard_name = vertically_integrated_x_momentum_flux_due_to_blocking_drag
   long_name = integrated x momentum flux from blocking drag
@@ -282,7 +282,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [dvsfc_bl]
   standard_name = vertically_integrated_y_momentum_flux_due_to_blocking_drag
   long_name = integrated y momentum flux from blocking drag
@@ -290,7 +290,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [g]
   standard_name = gravitational_acceleration
   long_name = gravitational acceleration

--- a/physics/gwdps.meta
+++ b/physics/gwdps.meta
@@ -218,10 +218,74 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [dvsfc]
   standard_name = instantaneous_y_stress_due_to_gravity_wave_drag
   long_name = meridional surface stress due to orographic gravity wave drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dtaux2d_ms]
+  standard_name = tendency_of_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = instantaneous change in x wind due to orographic gw drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[dtauy2d_ms]
+  standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = instantaneous change in y wind due to orographic gw drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[dtaux2d_bl]
+  standard_name = tendency_of_x_momentum_due_to_blocking_drag
+  long_name = x momentum tendency from blocking drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[dtauy2d_bl]
+  standard_name = tendency_of_y_momentum_due_to_blocking_drag
+  long_name = y momentum tendency from blocking drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[dusfc_ms]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = integrated x momentum flux from mesoscale gwd
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[dvsfc_ms]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = integrated y momentum flux from mesoscale gwd
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[dusfc_bl]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_blocking_drag
+  long_name = integrated x momentum flux from blocking drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[dvsfc_bl]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_blocking_drag
+  long_name = integrated y momentum flux from blocking drag
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
@@ -310,6 +374,13 @@
   type = real
   kind = kind_phys
   intent = out
+[ldiag_ugwp]
+  standard_name = flag_for_unified_gravity_wave_physics_diagnostics
+  long_name = flag for CIRES UGWP Diagnostics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/gwdps.meta
+++ b/physics/gwdps.meta
@@ -244,16 +244,16 @@
   kind = kind_phys
   intent = inout
 [dtaux2d_bl]
-  standard_name = tendency_of_x_momentum_due_to_blocking_drag
-  long_name = x momentum tendency from blocking drag
+  standard_name = tendency_of_x_wind_due_to_blocking_drag
+  long_name = x wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = inout
 [dtauy2d_bl]
-  standard_name = tendency_of_y_momentum_due_to_blocking_drag
-  long_name = y momentum tendency from blocking drag
+  standard_name = tendency_of_y_wind_due_to_blocking_drag
+  long_name = y wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real

--- a/physics/ugwpv1_gsldrag.F90
+++ b/physics/ugwpv1_gsldrag.F90
@@ -544,7 +544,7 @@ contains
 ! dusfcg,  dvsfcg
 !
 !
-       call drag_suite_run(im, levs, ak, bk, Pdvdt, Pdudt, Pdtdt,    &
+       call drag_suite_run(im, levs, Pdvdt, Pdudt, Pdtdt,            &
                  ugrs,vgrs,tgrs,q1,                                  &
                  kpbl,prsi,del,prsl,prslk,phii,phil,dtp,             &
                  kdt,hprime,oc,oa4,clx,varss,oc1ss,oa4ss,            &

--- a/physics/ugwpv1_gsldrag.meta
+++ b/physics/ugwpv1_gsldrag.meta
@@ -746,7 +746,7 @@
   intent = in
 [dudt_ogw]
   standard_name = tendency_of_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = x momentum tendency from meso scale ogw
+  long_name = x wind tendency from meso scale ogw
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -754,7 +754,7 @@
   intent = out
 [dvdt_ogw]
   standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = y momentum tendency from meso scale ogw
+  long_name = y wind tendency from meso scale ogw
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -777,16 +777,16 @@
   kind = kind_phys
   intent = out
 [dudt_obl]
-  standard_name = tendency_of_x_momentum_due_to_blocking_drag
-  long_name = x momentum tendency from blocking drag
+  standard_name = tendency_of_x_wind_due_to_blocking_drag
+  long_name = x wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dvdt_obl]
-  standard_name = tendency_of_y_momentum_due_to_blocking_drag
-  long_name = y momentum tendency from blocking drag
+  standard_name = tendency_of_y_wind_due_to_blocking_drag
+  long_name = y wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -809,16 +809,16 @@
   kind = kind_phys
   intent = out
 [dudt_oss]
-  standard_name = tendency_of_x_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = x momentum tendency from small scale gwd
+  standard_name = tendency_of_x_wind_due_to_small_scale_gravity_wave_drag
+  long_name = x wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dvdt_oss]
-  standard_name = tendency_of_y_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = y momentum tendency from small scale gwd
+  standard_name = tendency_of_y_wind_due_to_small_scale_gravity_wave_drag
+  long_name = y wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -841,16 +841,16 @@
   kind = kind_phys
   intent = out
 [dudt_ofd]
-  standard_name = tendency_of_x_momentum_due_to_form_drag
-  long_name = x momentum tendency from form drag
+  standard_name = tendency_of_x_wind_due_to_form_drag
+  long_name = x wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dvdt_ofd]
-  standard_name = tendency_of_y_momentum_due_to_form_drag
-  long_name = y momentum tendency from form drag
+  standard_name = tendency_of_y_wind_due_to_form_drag
+  long_name = y wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real

--- a/physics/ugwpv1_gsldrag.meta
+++ b/physics/ugwpv1_gsldrag.meta
@@ -198,21 +198,21 @@
   type = logical
   intent = in
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  standard_name = do_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
   long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_gsl_drag_ss]
-  standard_name = flag_for_gsl_drag_suite_small_scale_orographic_drag
+  standard_name = do_gsl_drag_suite_small_scale_orographic_drag
   long_name = flag to activate GSL drag suite - small-scale GWD
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_gsl_drag_tofd]
-  standard_name = flag_for_gsl_drag_suite_turbulent_orographic_form_drag
+  standard_name = do_gsl_drag_suite_turbulent_orographic_form_drag
   long_name = flag to activate GSL drag suite - turb orog form drag
   units = flag
   dimensions = ()
@@ -382,21 +382,21 @@
   type = logical
   intent = in
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  standard_name = do_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
   long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_gsl_drag_ss]
-  standard_name = flag_for_gsl_drag_suite_small_scale_orographic_drag
+  standard_name = do_gsl_drag_suite_small_scale_orographic_drag
   long_name = flag to activate GSL drag suite - small-scale GWD
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_gsl_drag_tofd]
-  standard_name = flag_for_gsl_drag_suite_turbulent_orographic_form_drag
+  standard_name = do_gsl_drag_suite_turbulent_orographic_form_drag
   long_name = flag to activate GSL drag suite - turb orog form drag
   units = flag
   dimensions = ()
@@ -445,7 +445,7 @@
   type = logical
   intent = in
 [ugwp_seq_update]
-  standard_name = ugwp_sequential_update_flag
+  standard_name = do_ugwp_sequential_update
   long_name = flag for ugwp sequential update
   units = flag
   dimensions = ()

--- a/physics/ugwpv1_gsldrag.meta
+++ b/physics/ugwpv1_gsldrag.meta
@@ -198,8 +198,8 @@
   type = logical
   intent = in
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_large_scale_orographic_and_blocking_drag
-  long_name = flag to activate GSL drag suite - large-scale GWD and blocking
+  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
@@ -307,6 +307,22 @@
   dimensions = ()
   type = integer
   intent = in
+[ak]
+  standard_name = sigma_pressure_hybrid_coordinate_a_coefficient
+  long_name = a parameter for sigma pressure level calculations
+  units = Pa
+  dimensions = (vertical_interface_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[bk]
+  standard_name = sigma_pressure_hybrid_coordinate_b_coefficient
+  long_name = b parameter for sigma pressure level calculations
+  units = none
+  dimensions = (vertical_interface_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
 [ntrac]
   standard_name = number_of_tracers
   long_name = number of tracers
@@ -366,8 +382,8 @@
   type = logical
   intent = in
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_large_scale_orographic_and_blocking_drag
-  long_name = flag to activate GSL drag suite - large-scale GWD and blocking
+  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
@@ -424,6 +440,13 @@
 [ldiag_ugwp]
   standard_name = flag_for_unified_gravity_wave_physics_diagnostics
   long_name = flag for CIRES UGWP Diagnostics
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
+[ugwp_seq_update]
+  standard_name = ugwp_sequential_update_flag
+  long_name = flag for ugwp sequential update
   units = flag
   dimensions = ()
   type = logical

--- a/physics/ugwpv1_gsldrag_post.F90
+++ b/physics/ugwpv1_gsldrag_post.F90
@@ -9,14 +9,21 @@ contains
 !> \section arg_table_ugwpv1_gsldrag_post_run Argument Table
 !! \htmlinclude ugwpv1_gsldrag_post_run.html
 !!
-     subroutine ugwpv1_gsldrag_post_run ( im, levs,                   &
-         ldiag_ugwp, dtf,                                             &
-         dudt_gw, dvdt_gw, dtdt_gw, du_ofdcol, du_oblcol, tau_ogw,    &
-         tau_ngw, zobl, zlwb, zogw, dudt_obl, dudt_ofd, dudt_ogw,     &
-         tot_zmtb, tot_zlwb, tot_zogw,                                &
+     subroutine ugwpv1_gsldrag_post_run ( im, levs, ldiag_ugwp,       &
+         dtf, dudt_gw, dvdt_gw, dtdt_gw,                              &
+         tau_ogw, tau_ngw, zobl, zlwb, zogw, dudt_obl, dvdt_obl,      &
+         dudt_ofd, dvdt_ofd, dudt_ogw, dvdt_ogw,                      &
+         dudt_oss, dvdt_oss, tot_zmtb, tot_zlwb, tot_zogw,            &
          tot_tofd, tot_mtb, tot_ogw, tot_ngw,                         &
          du3dt_mtb,du3dt_ogw, du3dt_tms, du3dt_ngw, dv3dt_ngw,        &
-         dtdt, dudt, dvdt, errmsg, errflg)
+         dudt_ngw, dvdt_ngw, dtdt_ngw,                                &
+         ldu3dt_ngw, ldv3dt_ngw, ldt3dt_ngw,                          &
+         dws3dt_ogw, dws3dt_obl, dws3dt_oss, dws3dt_ofd,              &
+         ldu3dt_ogw, ldu3dt_obl, ldu3dt_oss, ldu3dt_ofd,              &
+         du_ogwcol, dv_ogwcol, du_oblcol, dv_oblcol, du_osscol,       &
+         dv_osscol, du_ofdcol, dv_ofdcol, du3_ogwcol, dv3_ogwcol,     &
+         du3_oblcol, dv3_oblcol, du3_osscol, dv3_osscol, du3_ofdcol,  &
+         dv3_ofdcol, dtdt, dudt, dvdt, errmsg, errflg)
 
         use machine,                only: kind_phys
 
@@ -33,8 +40,25 @@ contains
         real(kind=kind_phys), intent(inout), dimension(:)   :: tot_zmtb, tot_zlwb, tot_zogw
 	
         real(kind=kind_phys), intent(in),    dimension(:,:) :: dtdt_gw, dudt_gw, dvdt_gw
-        real(kind=kind_phys), intent(in),    dimension(:,:) :: dudt_obl, dudt_ogw, dudt_ofd
-        real(kind=kind_phys), intent(inout), dimension(:,:) :: du3dt_mtb, du3dt_ogw, du3dt_tms, du3dt_ngw, dv3dt_ngw
+        real(kind=kind_phys), intent(in),    dimension(:,:) :: dudt_obl, dvdt_obl, dudt_ogw
+        real(kind=kind_phys), intent(in),    dimension(:,:) :: dvdt_ogw, dudt_ofd, dvdt_ofd
+        real(kind=kind_phys), intent(in),    dimension(:,:) :: dudt_oss, dvdt_oss
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: du3dt_mtb, du3dt_ogw, du3dt_tms
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: du3dt_ngw, dv3dt_ngw
+        real(kind=kind_phys), intent(in),    dimension(:,:) :: dudt_ngw, dvdt_ngw, dtdt_ngw
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: ldu3dt_ngw, ldv3dt_ngw, ldt3dt_ngw
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: dws3dt_ogw, dws3dt_obl
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: dws3dt_oss, dws3dt_ofd
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: ldu3dt_ogw, ldu3dt_obl
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: ldu3dt_oss, ldu3dt_ofd
+        real(kind=kind_phys), intent(in),    dimension(:)   :: du_ogwcol, dv_ogwcol
+        real(kind=kind_phys), intent(in),    dimension(:)   :: dv_oblcol
+        real(kind=kind_phys), intent(in),    dimension(:)   :: du_osscol, dv_osscol
+        real(kind=kind_phys), intent(in),    dimension(:)   :: dv_ofdcol
+        real(kind=kind_phys), intent(inout), dimension(:)   :: du3_ogwcol, dv3_ogwcol
+        real(kind=kind_phys), intent(inout), dimension(:)   :: du3_oblcol, dv3_oblcol
+        real(kind=kind_phys), intent(inout), dimension(:)   :: du3_osscol, dv3_osscol
+        real(kind=kind_phys), intent(inout), dimension(:)   :: du3_ofdcol, dv3_ofdcol
 	
         real(kind=kind_phys), intent(inout), dimension(:,:) :: dtdt, dudt, dvdt
 
@@ -63,6 +87,32 @@ contains
           du3dt_ogw = du3dt_ogw + dtf *dudt_ogw
           du3dt_ngw = du3dt_ngw + dtf *dudt_gw
           dv3dt_ngw = dv3dt_ngw + dtf *dvdt_gw
+
+          dws3dt_ogw = dws3dt_ogw + dtf *sqrt(dudt_ogw**2+dvdt_ogw**2)
+          dws3dt_obl = dws3dt_obl + dtf *sqrt(dudt_obl**2+dvdt_obl**2)
+
+          du3_ogwcol = du3_ogwcol + dtf *du_ogwcol
+          dv3_ogwcol = dv3_ogwcol + dtf *dv_ogwcol
+          du3_oblcol = du3_oblcol + dtf *du_oblcol
+          dv3_oblcol = dv3_oblcol + dtf *dv_oblcol
+
+          dws3dt_oss = dws3dt_oss + dtf *sqrt(dudt_oss**2+dvdt_oss**2)
+          dws3dt_ofd = dws3dt_ofd + dtf *sqrt(dudt_ofd**2+dvdt_ofd**2)
+
+          ldu3dt_ogw = ldu3dt_ogw + dtf *dudt_ogw
+          ldu3dt_obl = ldu3dt_obl + dtf *dudt_obl
+          ldu3dt_oss = ldu3dt_oss + dtf *dudt_oss
+          ldu3dt_ofd = ldu3dt_ofd + dtf *dudt_ofd
+
+          du3_osscol = du3_osscol + dtf*du_osscol
+          dv3_osscol = dv3_osscol + dtf*dv_osscol
+          du3_ofdcol = du3_ofdcol + dtf*du_ofdcol
+          dv3_ofdcol = dv3_ofdcol + dtf*dv_ofdcol
+
+          ! Special treatment for non-stationary GWD diagnostics
+          ldu3dt_ngw = ldu3dt_ngw + dtf *dudt_ngw
+          ldv3dt_ngw = ldv3dt_ngw + dtf *dvdt_ngw
+          ldt3dt_ngw = ldt3dt_ngw + dtf *dtdt_ngw
         endif
 	
 !=====================================================================

--- a/physics/ugwpv1_gsldrag_post.meta
+++ b/physics/ugwpv1_gsldrag_post.meta
@@ -60,22 +60,6 @@
   type = real
   kind = kind_phys
   intent = in
-[du_ofdcol]
-  standard_name = vertically_integrated_x_momentum_flux_due_to_form_drag
-  long_name = integrated x momentum flux from form drag
-  units = Pa
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
-[du_oblcol]
-  standard_name = vertically_integrated_x_momentum_flux_due_to_blocking_drag
-  long_name = integrated x momentum flux from blocking drag
-  units = Pa
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
 [tau_ogw]
   standard_name = instantaneous_momentum_flux_due_to_orographic_gravity_wave_drag
   long_name = momentum flux or stress due to orographic gravity wave drag
@@ -124,6 +108,14 @@
   type = real
   kind = kind_phys
   intent = in
+[dvdt_obl]
+  standard_name = tendency_of_y_momentum_due_to_blocking_drag
+  long_name = y momentum tendency from blocking drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
 [dudt_ofd]
   standard_name = tendency_of_x_momentum_due_to_form_drag
   long_name = x momentum tendency from form drag
@@ -132,9 +124,41 @@
   type = real
   kind = kind_phys
   intent = in
+[dvdt_ofd]
+  standard_name = tendency_of_y_momentum_due_to_form_drag
+  long_name = y momentum tendency from form drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
 [dudt_ogw]
   standard_name = tendency_of_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = x momentum tendency from meso scale ogw
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dvdt_ogw]
+  standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = y momentum tendency from meso scale ogw
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dudt_oss]
+  standard_name = tendency_of_x_momentum_due_to_small_scale_gravity_wave_drag
+  long_name = x momentum tendency from small scale gwd
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dvdt_oss]
+  standard_name = tendency_of_y_momentum_due_to_small_scale_gravity_wave_drag
+  long_name = y momentum tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -233,6 +257,246 @@
   long_name = time integral of change in y wind due to NGW
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dudt_ngw]
+  standard_name = tendency_of_x_wind_due_to_nonorographic_gravity_wave_drag
+  long_name = zonal wind tendency due to non-stationary GWs
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dvdt_ngw]
+  standard_name = tendency_of_y_wind_due_to_nonorographic_gravity_wave_drag
+  long_name = meridional wind tendency due to non-stationary GWs
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dtdt_ngw]
+  standard_name = tendency_of_air_temperature_due_to_nonorographic_gravity_wave_drag
+  long_name = air temperature tendency due to non-stationary GWs
+  units = K s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[ldu3dt_ngw]
+  standard_name = cumulative_change_in_x_wind_due_to_convective_gravity_wave_drag
+  long_name = cumulative change in x wind due to convective gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldv3dt_ngw]
+  standard_name = cumulative_change_in_y_wind_due_to_convective_gravity_wave_drag
+  long_name = cumulative change in y wind due to convective gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldt3dt_ngw]
+  standard_name = cumulative_change_in_temperature_due_to_convective_gravity_wave_drag
+  long_name = cumulative change in temperature due to convective gravity wave drag
+  units = K
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dws3dt_ogw]
+  standard_name = cumulative_change_in_wind_speed_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative change in wind speed due to mesoscale orographic gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dws3dt_obl]
+  standard_name = cumulative_change_in_wind_speed_due_to_blocking_drag
+  long_name = cumulative change in wind speed due to blocking drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dws3dt_oss]
+  standard_name = cumulative_change_in_wind_speed_due_to_small_scale_orographic_gravity_wave_drag
+  long_name = cumulative change in wind speed due to small scale orographic gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dws3dt_ofd]
+  standard_name = cumulative_change_in_wind_speed_due_to_turbulent_orographic_form_drag
+  long_name = cumulative change in wind speed due to turbulent orographic form drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldu3dt_ogw]
+  standard_name = cumulative_change_in_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative change in x wind due to mesoscale orographic gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldu3dt_obl]
+  standard_name = cumulative_change_in_x_wind_due_to_blocking_drag
+  long_name = cumulative change in x wind due to blocking drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldu3dt_oss]
+  standard_name = cumulative_change_in_x_wind_due_to_small_scale_gravity_wave_drag
+  long_name = cumulative change in x wind due to small scale gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldu3dt_ofd]
+  standard_name = cumulative_change_in_x_wind_due_to_form_drag
+  long_name = cumulative change in x wind due to form drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[du_ogwcol]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = integrated x momentum flux from meso scale ogw
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[dv_ogwcol]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = integrated y momentum flux from meso scale ogw
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[du_oblcol]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_blocking_drag
+  long_name = integrated x momentum flux from blocking drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[dv_oblcol]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_blocking_drag
+  long_name = integrated y momentum flux from blocking drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[du_osscol]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_small_scale_gravity_wave_drag
+  long_name = integrated x momentum flux from small scale gwd
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[dv_osscol]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_small_scale_gravity_wave_drag
+  long_name = integrated y momentum flux from small scale gwd
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[du_ofdcol]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_form_drag
+  long_name = integrated x momentum flux from form drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[dv_ofdcol]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_form_drag
+  long_name = integrated y momentum flux from form drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[du3_ogwcol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative integrated x momentum flux from mesoscale orographic gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dv3_ogwcol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative integrated y momentum flux from mesoscale orographic gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[du3_oblcol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_blocking_drag
+  long_name = cumulative integrated x momentum flux from blocking drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dv3_oblcol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_to_blocking_drag
+  long_name = cumulative integrated y momentum flux from blocking drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[du3_osscol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_small_scale_gravity_wave_drag
+  long_name = cumulative integrated x momentum flux from small scale gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dv3_osscol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_small_scale_gravity_wave_drag
+  long_name = cumulative integrated y momentum flux from small scale gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[du3_ofdcol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_form_drag
+  long_name = cumulative integrated x momentum flux from form drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dv3_ofdcol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_to_form_drag
+  long_name = cumulative integrated y momentum flux from form drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = inout

--- a/physics/ugwpv1_gsldrag_post.meta
+++ b/physics/ugwpv1_gsldrag_post.meta
@@ -101,32 +101,32 @@
   kind = kind_phys
   intent = in
 [dudt_obl]
-  standard_name = tendency_of_x_momentum_due_to_blocking_drag
-  long_name = x momentum tendency from blocking drag
+  standard_name = tendency_of_x_wind_due_to_blocking_drag
+  long_name = x wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [dvdt_obl]
-  standard_name = tendency_of_y_momentum_due_to_blocking_drag
-  long_name = y momentum tendency from blocking drag
+  standard_name = tendency_of_y_wind_due_to_blocking_drag
+  long_name = y wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [dudt_ofd]
-  standard_name = tendency_of_x_momentum_due_to_form_drag
-  long_name = x momentum tendency from form drag
+  standard_name = tendency_of_x_wind_due_to_form_drag
+  long_name = x wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [dvdt_ofd]
-  standard_name = tendency_of_y_momentum_due_to_form_drag
-  long_name = y momentum tendency from form drag
+  standard_name = tendency_of_y_wind_due_to_form_drag
+  long_name = y wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -134,7 +134,7 @@
   intent = in
 [dudt_ogw]
   standard_name = tendency_of_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = x momentum tendency from meso scale ogw
+  long_name = x wind tendency from meso scale ogw
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
@@ -142,23 +142,23 @@
   intent = in
 [dvdt_ogw]
   standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = y momentum tendency from meso scale ogw
+  long_name = y wind tendency from meso scale ogw
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [dudt_oss]
-  standard_name = tendency_of_x_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = x momentum tendency from small scale gwd
+  standard_name = tendency_of_x_wind_due_to_small_scale_gravity_wave_drag
+  long_name = x wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [dvdt_oss]
-  standard_name = tendency_of_y_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = y momentum tendency from small scale gwd
+  standard_name = tendency_of_y_wind_due_to_small_scale_gravity_wave_drag
+  long_name = y wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real

--- a/physics/ugwpv1_gsldrag_post.meta
+++ b/physics/ugwpv1_gsldrag_post.meta
@@ -411,7 +411,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [dv_osscol]
   standard_name = vertically_integrated_y_momentum_flux_due_to_small_scale_gravity_wave_drag
   long_name = integrated y momentum flux from small scale gwd
@@ -419,7 +419,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [du_ofdcol]
   standard_name = vertically_integrated_x_momentum_flux_due_to_form_drag
   long_name = integrated x momentum flux from form drag
@@ -427,7 +427,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [dv_ofdcol]
   standard_name = vertically_integrated_y_momentum_flux_due_to_form_drag
   long_name = integrated y momentum flux from form drag
@@ -435,7 +435,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [du3_ogwcol]
   standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = cumulative integrated x momentum flux from mesoscale orographic gravity wave drag

--- a/physics/unified_ugwp.F90
+++ b/physics/unified_ugwp.F90
@@ -354,8 +354,11 @@ contains
     real(kind=kind_phys), dimension(im, levs) :: Pdvdt, Pdudt
     real(kind=kind_phys), dimension(im, levs) :: Pdtdt, Pkdis
 
-    ! Variables for sequential updating of winds
-    ! LSGWD+BLOCKING and SSGWD+TOFD steps
+    ! Variables for optional sequential updating of winds between the
+    ! LSGWD+BLOCKING and SSGWD+TOFD steps.  They are placeholders
+    ! for the u,v winds that are updated within the scheme if
+    ! ugwp_seq_update == T, otherwise, they retain the values
+    ! passed to the scheme.
     real(kind=kind_phys), dimension(im, levs) :: uwnd1, vwnd1
  
     real(kind=kind_phys), parameter :: tamp_mpa=30.e-3

--- a/physics/unified_ugwp.F90
+++ b/physics/unified_ugwp.F90
@@ -5,7 +5,7 @@
 !!            a) the "traditional" EMC orograhic gravity wave drag and flow blocking scheme of gwdps.f
 !!            b) the v0 cires ugwp non-stationary GWD scheme
 !!      2) The GSL orographic drag suite (drag_suite.F90), as implmeneted in the RAP/HRRR, which includes:
-!!            a) large-scale gravity wave drag and low-level flow blocking -- active at horizontal scales
+!!            a) mesoscale gravity wave drag and low-level flow blocking -- active at horizontal scales
 !!               down to ~5km (Kim and Arakawa, 1995 \cite kim_and_arakawa_1995; Kim and Doyle, 2005 \cite kim_and_doyle_2005)
 !!            b) small-scale gravity wave drag scheme -- active typically in stable PBL at horizontal grid resolutions down to ~1km
 !!               (Steeneveld et al, 2008 \cite steeneveld_et_al_2008; Tsiringakis et al, 2017 \cite tsiringakis_et_al_2017)
@@ -25,10 +25,10 @@
 !!       do_ugwp_v0           -- activates V0 CIRES UGWP scheme - both orographic and non-stationary GWD
 !!       do_ugwp_v0_orog_only -- activates V0 CIRES UGWP scheme - orographic GWD only
 !!       do_ugwp_v0_nst_only  -- activates V0 CIRES UGWP scheme - non-stationary GWD only
-!!       do_gsl_drag_ls_bl    -- activates RAP/HRRR (GSL) large-scale GWD and blocking
+!!       do_gsl_drag_ls_bl    -- activates RAP/HRRR (GSL) mesoscale GWD and blocking
 !!       do_gsl_drag_ss       -- activates RAP/HRRR (GSL) small-scale GWD
 !!       do_gsl_drag_tofd     -- activates RAP/HRRR (GSL) turbulent orographic drag
-!! Note that only one "large-scale" scheme can be activated at a time.
+!! Note that only one "mesoscale" scheme can be activated at a time.
 !!
 
 module unified_ugwp
@@ -116,12 +116,12 @@ contains
       return
     end if
 
-    ! Test to make sure that at most only one large-scale/blocking
+    ! Test to make sure that at most only one mesoscale/blocking
     ! orographic drag scheme is chosen
     if ( (do_ugwp_v0.and.(do_ugwp_v0_orog_only.or.do_gsl_drag_ls_bl)) .or. &
          (do_ugwp_v0_orog_only.and.do_gsl_drag_ls_bl) ) then
 
-       write(errmsg,'(*(a))') "Logic error: Only one large-scale&
+       write(errmsg,'(*(a))') "Logic error: Only one mesoscale&
           &/blocking scheme (do_ugwp_v0,do_ugwp_v0_orog_only,&
           &do_gsl_drag_ls_bl can be chosen"
        errflg = 1
@@ -244,21 +244,23 @@ contains
 !! \htmlinclude unified_ugwp_run.html
 !!
 ! \section det_unified_ugwp GFS Unified GWP Scheme Detailed Algorithm
-     subroutine unified_ugwp_run(me,  master, im,  levs, ntrac, dtp, fhzero, kdt,      &
+     subroutine unified_ugwp_run(me, master, im, levs, ak,bk, ntrac, dtp, fhzero, kdt, &
          lonr, oro, oro_uf, hprime, nmtvr, oc, theta, sigma, gamma, elvmax, clx, oa4,  &
-         varss,oc1ss,oa4ss,ol4ss,dx,dusfc_ls,dvsfc_ls,dusfc_bl,dvsfc_bl,dusfc_ss,      &
-         dvsfc_ss,dusfc_fd,dvsfc_fd,dtaux2d_ls,dtauy2d_ls,dtaux2d_bl,dtauy2d_bl,       &
-         dtaux2d_ss,dtauy2d_ss,dtaux2d_fd,dtauy2d_fd,br1,hpbl,slmsk,                   &
-         do_tofd, ldiag_ugwp, cdmbgwd, jdat, xlat, xlat_d, sinlat, coslat, area,       &
+         varss,oc1ss,oa4ss,ol4ss,dx,dusfc_ms,dvsfc_ms,dusfc_bl,dvsfc_bl,dusfc_ss,      &
+         dvsfc_ss,dusfc_fd,dvsfc_fd,dtaux2d_ms,dtauy2d_ms,dtaux2d_bl,dtauy2d_bl,       &
+         dtaux2d_ss,dtauy2d_ss,dtaux2d_fd,dtauy2d_fd,dudt_ngw,dvdt_ngw,dtdt_ngw,       &
+         br1,hpbl,slmsk, do_tofd, ldiag_ugwp, ugwp_seq_update,                         &
+         cdmbgwd, jdat, xlat, xlat_d, sinlat, coslat, area,                            &
          ugrs, vgrs, tgrs, q1, prsi, prsl, prslk, phii, phil,                          &
          del, kpbl, dusfcg, dvsfcg, gw_dudt, gw_dvdt, gw_dtdt, gw_kdis,                &
          tau_tofd, tau_mtb, tau_ogw, tau_ngw, zmtb, zlwb, zogw,                        &
          dudt_mtb, dudt_tms, du3dt_mtb, du3dt_ogw, du3dt_tms,                          &
          dudt, dvdt, dtdt, rdxzb, con_g, con_omega, con_pi, con_cp, con_rd, con_rv,    &
          con_rerth, con_fvirt, rain, ntke, q_tke, dqdt_tke, lprnt, ipr,                &
-         dtend, dtidx, index_of_temperature, index_of_x_wind, index_of_y_wind,         &
-         index_of_process_orographic_gwd, index_of_process_nonorographic_gwd,          &
-         ldiag3d, lssav, flag_for_gwd_generic_tend, do_ugwp_v0, do_ugwp_v0_orog_only,  &
+         ldiag3d, dtend, dtidx, index_of_temperature, index_of_x_wind,                 &
+         index_of_y_wind, index_of_process_orographic_gwd,                             &
+         index_of_process_nonorographic_gwd,                                           &
+         lssav, flag_for_gwd_generic_tend, do_ugwp_v0, do_ugwp_v0_orog_only,           &
          do_ugwp_v0_nst_only, do_gsl_drag_ls_bl, do_gsl_drag_ss, do_gsl_drag_tofd,     &
          gwd_opt, spp_wts_gwd, spp_gwd, errmsg, errflg)
 
@@ -268,6 +270,7 @@ contains
     integer,                 intent(in) :: me, master, im, levs, ntrac, kdt, lonr, nmtvr
     integer,                 intent(in) :: gwd_opt
     integer,                 intent(in), dimension(:)       :: kpbl
+    real(kind=kind_phys),    intent(in), dimension(:)       :: ak, bk
     real(kind=kind_phys),    intent(in), dimension(:)       :: oro, oro_uf, hprime, oc, theta, sigma, gamma
     real(kind=kind_phys),    intent(in), dimension(:)       :: varss,oc1ss, dx
 
@@ -286,18 +289,20 @@ contains
     real(kind=kind_phys),    intent(in),    dimension(:,:)  :: q1
     real(kind=kind_phys),    intent(in) :: dtp, fhzero, cdmbgwd(:)
     integer, intent(in) :: jdat(:)
-    logical,                 intent(in) :: do_tofd, ldiag_ugwp
+    logical, intent(in) :: do_tofd, ldiag_ugwp, ugwp_seq_update
 
 !Output (optional):
     real(kind=kind_phys), intent(out) ::                          &
-      &                      dusfc_ls(:),dvsfc_ls(:),             &
+      &                      dusfc_ms(:),dvsfc_ms(:),             &
       &                      dusfc_bl(:),dvsfc_bl(:),             &
       &                      dusfc_ss(:),dvsfc_ss(:),             &
       &                      dusfc_fd(:),dvsfc_fd(:)
     real(kind=kind_phys), intent(out) ::                          &
+      &         dtaux2d_ms(:,:),dtauy2d_ms(:,:),                  &
       &         dtaux2d_bl(:,:),dtauy2d_bl(:,:),                  &
       &         dtaux2d_ss(:,:),dtauy2d_ss(:,:),                  &
-      &         dtaux2d_fd(:,:),dtauy2d_fd(:,:)
+      &         dtaux2d_fd(:,:),dtauy2d_fd(:,:),                  &
+      &         dudt_ngw(:,:),dvdt_ngw(:,:),dtdt_ngw(:,:)
 
     real(kind=kind_phys), intent(in) ::     br1(:),               &
       &                                     hpbl(:),              &
@@ -308,7 +313,6 @@ contains
     real(kind=kind_phys),    intent(out), dimension(:)          :: tau_mtb, tau_ogw, tau_tofd, tau_ngw
     real(kind=kind_phys),    intent(out), dimension(:,:)        :: gw_dudt, gw_dvdt, gw_dtdt, gw_kdis
     real(kind=kind_phys),    intent(out), dimension(:,:)        :: dudt_mtb, dudt_tms
-    real(kind=kind_phys),    intent(out), dimension(:,:)        :: dtaux2d_ls, dtauy2d_ls
 
     real(kind=kind_phys), intent(inout) :: dtend(:,:,:)
     integer, intent(in) :: dtidx(:,:), index_of_temperature, index_of_x_wind, &
@@ -349,6 +353,10 @@ contains
     real(kind=kind_phys), dimension(im)       :: sgh30
     real(kind=kind_phys), dimension(im, levs) :: Pdvdt, Pdudt
     real(kind=kind_phys), dimension(im, levs) :: Pdtdt, Pkdis
+
+    ! Variables for sequential updating of winds
+    ! LSGWD+BLOCKING and SSGWD+TOFD steps
+    real(kind=kind_phys), dimension(im, levs) :: uwnd1, vwnd1
  
     real(kind=kind_phys), parameter :: tamp_mpa=30.e-3
 
@@ -366,38 +374,34 @@ contains
     errmsg = ''
     errflg = 0
 
+
     ! 1) ORO stationary GWs
     !    ------------------
 
-    ! Run the appropriate large-scale (large-scale GWD + blocking) scheme
-    ! Note:  In case of GSL drag_suite, this includes ss and tofd
-
-    if ( do_gsl_drag_ls_bl.or.do_gsl_drag_ss.or.do_gsl_drag_tofd ) then
-
-       call drag_suite_run(im,levs,dvdt,dudt,dtdt,ugrs,vgrs,tgrs,q1, &
-                 kpbl,prsi,del,prsl,prslk,phii,phil,dtp,             &
-                 kdt,hprime,oc,oa4,clx,varss,oc1ss,oa4ss,            &
-                 ol4ss,theta,sigma,gamma,elvmax,dtaux2d_ls,          &
-                 dtauy2d_ls,dtaux2d_bl,dtauy2d_bl,dtaux2d_ss,        &
-                 dtauy2d_ss,dtaux2d_fd,dtauy2d_fd,dusfcg,            &
-                 dvsfcg,dusfc_ls,dvsfc_ls,dusfc_bl,dvsfc_bl,         &
-                 dusfc_ss,dvsfc_ss,dusfc_fd,dvsfc_fd,                &
-                 slmsk,br1,hpbl,con_g,con_cp,con_rd,con_rv,          &
-                 con_fvirt,con_pi,lonr,                              &
-                 cdmbgwd,me,master,lprnt,ipr,rdxzb,dx,gwd_opt,       &
-                 do_gsl_drag_ls_bl,do_gsl_drag_ss,do_gsl_drag_tofd,  &
-                 dtend, dtidx, index_of_process_orographic_gwd,      &
-                 index_of_temperature, index_of_x_wind,              &
-                 index_of_y_wind, ldiag3d, spp_wts_gwd, spp_gwd,     &
-                 errmsg, errflg)
-!
-! put zeros due to xy GSL-drag style: dtaux2d_bl,dtauy2d_bl,dtaux2d_ss.......dusfc_ls,dvsfc_ls
-!
-        tau_mtb  = 0. ; tau_ogw  = 0. ; tau_tofd = 0.
-        dudt_mtb = 0. ; dudt_tms = 0.
-	
+    ! Initialize optional diagnostic variables for ORO drag
+    if ( ldiag_ugwp ) then
+       dusfc_ms(:) = 0.0
+       dvsfc_ms(:) = 0.0
+       dusfc_bl(:) = 0.0
+       dvsfc_bl(:) = 0.0
+       dusfc_ss(:) = 0.0
+       dvsfc_ss(:) = 0.0
+       dusfc_fd(:) = 0.0
+       dvsfc_fd(:) = 0.0
+       dtaux2d_ms(:,:)= 0.0
+       dtauy2d_ms(:,:)= 0.0
+       dtaux2d_bl(:,:)= 0.0
+       dtauy2d_bl(:,:)= 0.0
+       dtaux2d_ss(:,:)= 0.0
+       dtauy2d_ss(:,:)= 0.0
+       dtaux2d_fd(:,:)= 0.0
+       dtauy2d_fd(:,:)= 0.0
     end if
 
+
+    ! Prepare to run UGWP_v0 mesoscale GWD + blocking scheme
+    ! These tendency initializations pertain to the non-stationary GWD
+    ! scheme as well
     if ( do_ugwp_v0.or.do_ugwp_v0_orog_only.or.do_ugwp_v0_nst_only ) then
 
       do k=1,levs
@@ -411,11 +415,17 @@ contains
 
     end if
 
+    ! Initialize winds and temperature for sequential updating
+    ! NOTE: These will only be updated if ugwp_seq_update == .true.
+    uwnd1(:,:) = ugrs(:,:)
+    vwnd1(:,:) = vgrs(:,:)
+
     if ( do_ugwp_v0.or.do_ugwp_v0_orog_only ) then
 
       if (cdmbgwd(1) > 0.0 .or. cdmbgwd(2) > 0.0) then
 
-        ! Override nmtvr with nmtvr_temp = 14 for passing into gwdps_run if necessary
+        ! Override nmtvr with nmtvr_temp = 14 for passing into gwdps_run if
+        ! necessary
         if ( nmtvr == 24 ) then  ! gwd_opt = 2, 22, 3, or 33
            nmtvr_temp = 14
         else
@@ -426,11 +436,21 @@ contains
                    ugrs, vgrs, tgrs, q1,                               &
                    kpbl, prsi, del, prsl, prslk, phii, phil, dtp, kdt, &
                    hprime, oc, oa4, clx, theta, sigma, gamma,          &
-                   elvmax, dusfcg, dvsfcg,                             &
+                   elvmax, dusfcg, dvsfcg, dtaux2d_ms, dtauy2d_ms,     &
+                   dtaux2d_bl, dtauy2d_bl, dusfc_ms, dvsfc_ms,         &
+                   dusfc_bl, dvsfc_bl,                                 &
                    con_g,  con_cp, con_rd, con_rv, lonr,               &
                    nmtvr_temp, cdmbgwd, me, lprnt, ipr, rdxzb,         &
-                   errmsg, errflg)
+                   ldiag_ugwp, errmsg, errflg)
         if (errflg/=0) return
+
+        ! Update winds if sequential updating is selected
+        ! and SSGWD and TOFD will be calculated
+        if ( ugwp_seq_update .and. (do_gsl_drag_ss.or.do_gsl_drag_tofd) ) then
+           uwnd1(:,:) = uwnd1(:,:) + Pdudt(:,:)*dtp
+           vwnd1(:,:) = vwnd1(:,:) + Pdvdt(:,:)*dtp
+        endif
+
       endif
 
       tau_mtb   = 0.0  ; tau_ogw   = 0.0 ;  tau_tofd = 0.0
@@ -444,7 +464,7 @@ contains
         if(idtend>=1) then
           dtend(:,:,idtend) = dtend(:,:,idtend) + Pdudt*dtp
         endif
-        
+
         idtend = dtidx(index_of_y_wind,index_of_process_orographic_gwd)
         if(idtend>=1) then
           dtend(:,:,idtend) = dtend(:,:,idtend) + Pdvdt*dtp
@@ -455,8 +475,39 @@ contains
           dtend(:,:,idtend) = dtend(:,:,idtend) + Pdtdt*dtp
         endif
       endif
-   
-    end if 
+
+    end if
+
+
+
+    ! Run the appropriate mesoscale (mesoscale GWD + blocking) scheme
+    ! Note:  In case of GSL drag_suite, this includes ss and tofd
+
+    if ( do_gsl_drag_ls_bl.or.do_gsl_drag_ss.or.do_gsl_drag_tofd ) then
+
+       call drag_suite_run(im,levs,ak,bk,dvdt,dudt,dtdt,uwnd1,vwnd1, &
+                 tgrs,q1,kpbl,prsi,del,prsl,prslk,phii,phil,dtp,     &
+                 kdt,hprime,oc,oa4,clx,varss,oc1ss,oa4ss,            &
+                 ol4ss,theta,sigma,gamma,elvmax,dtaux2d_ms,          &
+                 dtauy2d_ms,dtaux2d_bl,dtauy2d_bl,dtaux2d_ss,        &
+                 dtauy2d_ss,dtaux2d_fd,dtauy2d_fd,dusfcg,            &
+                 dvsfcg,dusfc_ms,dvsfc_ms,dusfc_bl,dvsfc_bl,         &
+                 dusfc_ss,dvsfc_ss,dusfc_fd,dvsfc_fd,                &
+                 slmsk,br1,hpbl,con_g,con_cp,con_rd,con_rv,          &
+                 con_fvirt,con_pi,lonr,                              &
+                 cdmbgwd,me,master,lprnt,ipr,rdxzb,dx,gwd_opt,       &
+                 do_gsl_drag_ls_bl,do_gsl_drag_ss,do_gsl_drag_tofd,  &
+                 dtend, dtidx, index_of_process_orographic_gwd,      &
+                 index_of_temperature, index_of_x_wind,              &
+                 index_of_y_wind, ldiag3d, ldiag_ugwp,               &
+                 ugwp_seq_update, spp_wts_gwd, spp_gwd, errmsg, errflg)
+!
+! put zeros due to xy GSL-drag style: dtaux2d_bl,dtauy2d_bl,dtaux2d_ss.......dusfc_ms,dvsfc_ms
+!
+        tau_mtb  = 0. ; tau_ogw  = 0. ; tau_tofd = 0.
+        dudt_mtb = 0. ; dudt_tms = 0.
+	
+    end if
 
 
 
@@ -512,6 +563,11 @@ contains
         call fv3_ugwp_solv2_v0(im, levs, dtp, tgrs, ugrs, vgrs, q1,                        &
              prsl, prsi, phil, xlat_d, sinlat, coslat, gw_dudt, gw_dvdt, gw_dtdt, gw_kdis, &
              tau_ngw, me, master, kdt)
+
+        ! Save u, v, and t non-orogarphic tendencies for diagnostic output
+        dudt_ngw = gw_dudt
+        dvdt_ngw = gw_dvdt
+        dtdt_ngw = gw_dtdt
 
         do k=1,levs
           do i=1,im

--- a/physics/unified_ugwp.F90
+++ b/physics/unified_ugwp.F90
@@ -485,7 +485,7 @@ contains
 
     if ( do_gsl_drag_ls_bl.or.do_gsl_drag_ss.or.do_gsl_drag_tofd ) then
 
-       call drag_suite_run(im,levs,ak,bk,dvdt,dudt,dtdt,uwnd1,vwnd1, &
+       call drag_suite_run(im,levs,dvdt,dudt,dtdt,uwnd1,vwnd1,       &
                  tgrs,q1,kpbl,prsi,del,prsl,prslk,phii,phil,dtp,     &
                  kdt,hprime,oc,oa4,clx,varss,oc1ss,oa4ss,            &
                  ol4ss,theta,sigma,gamma,elvmax,dtaux2d_ms,          &

--- a/physics/unified_ugwp.meta
+++ b/physics/unified_ugwp.meta
@@ -191,8 +191,8 @@
   type = logical
   intent = in
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_large_scale_orographic_and_blocking_drag
-  long_name = flag to activate GSL drag suite - large-scale GWD and blocking
+  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
@@ -299,6 +299,22 @@
   units = count
   dimensions = ()
   type = integer
+  intent = in
+[ak]
+  standard_name = sigma_pressure_hybrid_coordinate_a_coefficient
+  long_name = a parameter for sigma pressure level calculations
+  units = Pa
+  dimensions = (vertical_interface_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[bk]
+  standard_name = sigma_pressure_hybrid_coordinate_b_coefficient
+  long_name = b parameter for sigma pressure level calculations
+  units = none
+  dimensions = (vertical_interface_dimension)
+  type = real
+  kind = kind_phys
   intent = in
 [ntrac]
   standard_name = number_of_tracers
@@ -464,17 +480,17 @@
   type = real
   kind = kind_phys
   intent = in
-[dusfc_ls]
+[dusfc_ms]
   standard_name = vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = integrated x momentum flux from large scale gwd
+  long_name = integrated x momentum flux from mesoscale gwd
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = out
-[dvsfc_ls]
+[dvsfc_ms]
   standard_name = vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
-  long_name = integrated y momentum flux from large scale gwd
+  long_name = integrated y momentum flux from mesoscale gwd
   units = Pa
   dimensions = (horizontal_loop_extent)
   type = real
@@ -528,7 +544,7 @@
   type = real
   kind = kind_phys
   intent = out
-[dtaux2d_ls]
+[dtaux2d_ms]
   standard_name = tendency_of_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = instantaneous change in x wind due to orographic gw drag
   units = m s-2
@@ -536,7 +552,7 @@
   type = real
   kind = kind_phys
   intent = out
-[dtauy2d_ls]
+[dtauy2d_ms]
   standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
   long_name = instantaneous change in y wind due to orographic gw drag
   units = m s-2
@@ -592,6 +608,30 @@
   type = real
   kind = kind_phys
   intent = out
+[dudt_ngw]
+  standard_name = tendency_of_x_wind_due_to_nonorographic_gravity_wave_drag
+  long_name = zonal wind tendency due to non-stationary GWs
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[dvdt_ngw]
+  standard_name = tendency_of_y_wind_due_to_nonorographic_gravity_wave_drag
+  long_name = meridional wind tendency due to non-stationary GWs
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
+[dtdt_ngw]
+  standard_name = tendency_of_air_temperature_due_to_nonorographic_gravity_wave_drag
+  long_name = air temperature tendency due to non-stationary GWs
+  units = K s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = out
 [br1]
   standard_name = bulk_richardson_number_at_lowest_model_level
   long_name = bulk Richardson number at the surface
@@ -628,6 +668,13 @@
   long_name = flag for CIRES UGWP Diagnostics
   units = flag
   dimensions = ()
+  type = logical
+  intent = in
+[ugwp_seq_update]
+  standard_name = ugwp_sequential_update_flag
+  long_name = flag for ugwp sequential update
+  units = flag 
+  dimensions = () 
   type = logical
   intent = in
 [cdmbgwd]
@@ -1151,8 +1198,8 @@
   type = logical
   intent = in
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_large_scale_orographic_and_blocking_drag
-  long_name = flag to activate GSL drag suite - large-scale GWD and blocking
+  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical

--- a/physics/unified_ugwp.meta
+++ b/physics/unified_ugwp.meta
@@ -191,21 +191,21 @@
   type = logical
   intent = in
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  standard_name = do_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
   long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_gsl_drag_ss]
-  standard_name = flag_for_gsl_drag_suite_small_scale_orographic_drag
+  standard_name = do_gsl_drag_suite_small_scale_orographic_drag
   long_name = flag to activate GSL drag suite - small-scale GWD
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_gsl_drag_tofd]
-  standard_name = flag_for_gsl_drag_suite_turbulent_orographic_form_drag
+  standard_name = do_gsl_drag_suite_turbulent_orographic_form_drag
   long_name = flag to activate GSL drag suite - turb orog form drag
   units = flag
   dimensions = ()
@@ -671,7 +671,7 @@
   type = logical
   intent = in
 [ugwp_seq_update]
-  standard_name = ugwp_sequential_update_flag
+  standard_name = do_ugwp_sequential_update
   long_name = flag for ugwp sequential update
   units = flag 
   dimensions = () 
@@ -1198,21 +1198,21 @@
   type = logical
   intent = in
 [do_gsl_drag_ls_bl]
-  standard_name = flag_for_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
+  standard_name = do_gsl_drag_suite_mesoscale_orographic_and_blocking_drag
   long_name = flag to activate GSL drag suite - mesoscale GWD and blocking
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_gsl_drag_ss]
-  standard_name = flag_for_gsl_drag_suite_small_scale_orographic_drag
+  standard_name = do_gsl_drag_suite_small_scale_orographic_drag
   long_name = flag to activate GSL drag suite - small-scale GWD
   units = flag
   dimensions = ()
   type = logical
   intent = in
 [do_gsl_drag_tofd]
-  standard_name = flag_for_gsl_drag_suite_turbulent_orographic_form_drag
+  standard_name = do_gsl_drag_suite_turbulent_orographic_form_drag
   long_name = flag to activate GSL drag suite - turb orog form drag
   units = flag
   dimensions = ()

--- a/physics/unified_ugwp.meta
+++ b/physics/unified_ugwp.meta
@@ -561,48 +561,48 @@
   kind = kind_phys
   intent = out
 [dtaux2d_bl]
-  standard_name = tendency_of_x_momentum_due_to_blocking_drag
-  long_name = x momentum tendency from blocking drag
+  standard_name = tendency_of_x_wind_due_to_blocking_drag
+  long_name = x wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtauy2d_bl]
-  standard_name = tendency_of_y_momentum_due_to_blocking_drag
-  long_name = y momentum tendency from blocking drag
+  standard_name = tendency_of_y_wind_due_to_blocking_drag
+  long_name = y wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtaux2d_ss]
-  standard_name = tendency_of_x_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = x momentum tendency from small scale gwd
+  standard_name = tendency_of_x_wind_due_to_small_scale_gravity_wave_drag
+  long_name = x wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtauy2d_ss]
-  standard_name = tendency_of_y_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = y momentum tendency from small scale gwd
+  standard_name = tendency_of_y_wind_due_to_small_scale_gravity_wave_drag
+  long_name = y wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtaux2d_fd]
-  standard_name = tendency_of_x_momentum_due_to_form_drag
-  long_name = x momentum tendency from form drag
+  standard_name = tendency_of_x_wind_due_to_form_drag
+  long_name = x wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = out
 [dtauy2d_fd]
-  standard_name = tendency_of_y_momentum_due_to_form_drag
-  long_name = y momentum tendency from form drag
+  standard_name = tendency_of_y_wind_due_to_form_drag
+  long_name = y wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real

--- a/physics/unified_ugwp_post.F90
+++ b/physics/unified_ugwp_post.F90
@@ -10,12 +10,21 @@ contains
 !! \section arg_table_unified_ugwp_post_run Argument Table
 !! \htmlinclude unified_ugwp_post_run.html
 !!
-     subroutine unified_ugwp_post_run (ldiag_ugwp, dtf, im, levs,     &
+     subroutine unified_ugwp_post_run (ldiag3d, ldiag_ugwp,         &
+         dtf, im, levs,                                             &
          gw_dtdt, gw_dudt, gw_dvdt, tau_tofd, tau_mtb, tau_ogw,     &
-         tau_ngw, zmtb, zlwb, zogw, dudt_mtb, dudt_ogw, dudt_tms,   &
-         tot_zmtb, tot_zlwb, tot_zogw,                              &
+         tau_ngw, zmtb, zlwb, zogw, dudt_mtb, dudt_ogw, dvdt_ogw,   &
+         dudt_tms, tot_zmtb, tot_zlwb, tot_zogw,                    &
          tot_tofd, tot_mtb, tot_ogw, tot_ngw,                       &
          du3dt_mtb,du3dt_ogw, du3dt_tms, du3dt_ngw, dv3dt_ngw,      &
+         ldu3dt_ogw, ldu3dt_obl, ldu3dt_oss, ldu3dt_ofd,            &
+         dudt_ngw, dvdt_ngw, dtdt_ngw,                              &
+         ldu3dt_ngw, ldv3dt_ngw, ldt3dt_ngw, dudt_obl, dvdt_obl,    &
+         dudt_oss, dvdt_oss, dudt_ofd, dvdt_ofd, dws3dt_ogw,        &
+         dws3dt_obl, dws3dt_oss, dws3dt_ofd, du_ogwcol, dv_ogwcol,  &
+         du_oblcol, dv_oblcol, du_osscol, dv_osscol, du_ofdcol,     &
+         dv_ofdcol, du3_ogwcol, dv3_ogwcol, du3_oblcol, dv3_oblcol, &
+         du3_osscol, dv3_osscol, du3_ofdcol, dv3_ofdcol,            & 
          dtdt, dudt, dvdt, errmsg, errflg)
 
         use machine,                only: kind_phys
@@ -26,13 +35,30 @@ contains
         integer,              intent(in) :: im, levs
         real(kind=kind_phys), intent(in) :: dtf
         logical,              intent(in) :: ldiag_ugwp      !< flag for CIRES UGWP Diagnostics
+        logical,              intent(in) :: ldiag3d
 
         real(kind=kind_phys), intent(in),    dimension(:)   :: zmtb, zlwb, zogw
         real(kind=kind_phys), intent(in),    dimension(:)   :: tau_mtb, tau_ogw, tau_tofd, tau_ngw
         real(kind=kind_phys), intent(inout), dimension(:)   :: tot_mtb, tot_ogw, tot_tofd, tot_ngw
         real(kind=kind_phys), intent(inout), dimension(:)   :: tot_zmtb, tot_zlwb, tot_zogw
-        real(kind=kind_phys), intent(in),    dimension(:,:) :: gw_dtdt, gw_dudt, gw_dvdt, dudt_mtb, dudt_ogw, dudt_tms
+        real(kind=kind_phys), intent(in),    dimension(:,:) :: gw_dtdt, gw_dudt, gw_dvdt, dudt_mtb
+        real(kind=kind_phys), intent(in),    dimension(:,:) :: dudt_ogw, dvdt_ogw, dudt_tms
         real(kind=kind_phys), intent(inout), dimension(:,:) :: du3dt_mtb, du3dt_ogw, du3dt_tms, du3dt_ngw, dv3dt_ngw
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: ldu3dt_ogw, ldu3dt_obl, ldu3dt_oss, ldu3dt_ofd
+        real(kind=kind_phys), intent(in),    dimension(:,:) :: dudt_ngw, dvdt_ngw, dtdt_ngw
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: ldu3dt_ngw, ldv3dt_ngw, ldt3dt_ngw
+        real(kind=kind_phys), intent(in),    dimension(:,:) :: dudt_obl, dvdt_obl
+        real(kind=kind_phys), intent(in),    dimension(:,:) :: dudt_oss, dvdt_oss, dudt_ofd, dvdt_ofd
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: dws3dt_obl, dws3dt_ogw
+        real(kind=kind_phys), intent(inout), dimension(:,:) :: dws3dt_oss, dws3dt_ofd
+        real(kind=kind_phys), intent(in),    dimension(:)   :: du_ogwcol, dv_ogwcol
+        real(kind=kind_phys), intent(in),    dimension(:)   :: du_oblcol, dv_oblcol
+        real(kind=kind_phys), intent(in),    dimension(:)   :: du_osscol, dv_osscol
+        real(kind=kind_phys), intent(in),    dimension(:)   :: du_ofdcol, dv_ofdcol
+        real(kind=kind_phys), intent(inout), dimension(:)   :: du3_ogwcol, dv3_ogwcol
+        real(kind=kind_phys), intent(inout), dimension(:)   :: du3_oblcol, dv3_oblcol
+        real(kind=kind_phys), intent(inout), dimension(:)   :: du3_osscol, dv3_osscol
+        real(kind=kind_phys), intent(inout), dimension(:)   :: du3_ofdcol, dv3_ofdcol
         real(kind=kind_phys), intent(inout), dimension(:,:) :: dtdt, dudt, dvdt
 
         character(len=*),        intent(out) :: errmsg
@@ -57,7 +83,28 @@ contains
           du3dt_ogw = du3dt_ogw + dtf *dudt_ogw
           du3dt_ngw = du3dt_ngw + dtf *gw_dudt
           dv3dt_ngw = dv3dt_ngw + dtf *gw_dvdt
-        endif
+
+          dws3dt_ogw = dws3dt_ogw + dtf *sqrt(dudt_ogw**2+dvdt_ogw**2)
+          dws3dt_obl = dws3dt_obl + dtf *sqrt(dudt_obl**2+dvdt_obl**2)
+          dws3dt_oss = dws3dt_oss + dtf *sqrt(dudt_oss**2+dvdt_oss**2)
+          dws3dt_ofd = dws3dt_ofd + dtf *sqrt(dudt_ofd**2+dvdt_ofd**2)
+          ldu3dt_ogw  = ldu3dt_ogw  + dtf *dudt_ogw
+          ldu3dt_obl  = ldu3dt_obl  + dtf *dudt_obl
+          ldu3dt_oss  = ldu3dt_oss  + dtf *dudt_oss
+          ldu3dt_ofd  = ldu3dt_ofd  + dtf *dudt_ofd
+          du3_ogwcol = du3_ogwcol + dtf *du_ogwcol
+          dv3_ogwcol = dv3_ogwcol + dtf *dv_ogwcol
+          du3_oblcol = du3_oblcol + dtf *du_oblcol
+          dv3_oblcol = dv3_oblcol + dtf *dv_oblcol
+          du3_osscol = du3_osscol + dtf *du_osscol
+          dv3_osscol = dv3_osscol + dtf *dv_osscol
+          du3_ofdcol = du3_ofdcol + dtf *du_ofdcol
+          dv3_ofdcol = dv3_ofdcol + dtf *dv_ofdcol
+          ! Special treatment for non-stationary GWD diagnostics
+          ldu3dt_ngw = ldu3dt_ngw + dtf *dudt_ngw
+          ldv3dt_ngw = ldv3dt_ngw + dtf *dvdt_ngw
+          ldt3dt_ngw = ldt3dt_ngw + dtf *dtdt_ngw
+        end if
 
         dtdt = dtdt + gw_dtdt
         dudt = dudt + gw_dudt

--- a/physics/unified_ugwp_post.meta
+++ b/physics/unified_ugwp_post.meta
@@ -7,6 +7,13 @@
 [ccpp-arg-table]
   name = unified_ugwp_post_run
   type = scheme
+[ldiag3d]
+  standard_name = flag_for_diagnostics_3D
+  long_name = flag for 3d diagnostic fields
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [ldiag_ugwp]
   standard_name = flag_for_unified_gravity_wave_physics_diagnostics
   long_name = flag for CIRES UGWP Diagnostics
@@ -132,6 +139,14 @@
   type = real
   kind = kind_phys
   intent = in
+[dvdt_ogw]
+  standard_name = tendency_of_y_wind_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = y momentum tendency from meso scale ogw
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
 [dudt_tms]
   standard_name = tendency_of_x_wind_due_to_turbulent_orographic_form_drag
   long_name = instantaneous change in x wind due to TOFD
@@ -233,6 +248,294 @@
   long_name = time integral of change in y wind due to NGW
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldu3dt_ogw]
+  standard_name = cumulative_change_in_x_wind_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative change in x wind due to mesoscale orographic gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldu3dt_obl]
+  standard_name = cumulative_change_in_x_wind_due_to_blocking_drag
+  long_name = cumulative change in x wind due to blocking drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldu3dt_oss]
+  standard_name = cumulative_change_in_x_wind_due_to_small_scale_gravity_wave_drag
+  long_name = cumulative change in x wind due to small scale gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldu3dt_ofd]
+  standard_name = cumulative_change_in_x_wind_due_to_form_drag
+  long_name = cumulative change in x wind due to form drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dudt_ngw]
+  standard_name = tendency_of_x_wind_due_to_nonorographic_gravity_wave_drag
+  long_name = zonal wind tendency due to non-stationary GWs
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dvdt_ngw]
+  standard_name = tendency_of_y_wind_due_to_nonorographic_gravity_wave_drag
+  long_name = meridional wind tendency due to non-stationary GWs
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dtdt_ngw]
+  standard_name = tendency_of_air_temperature_due_to_nonorographic_gravity_wave_drag
+  long_name = air temperature tendency due to non-stationary GWs
+  units = K s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[ldu3dt_ngw]
+  standard_name = cumulative_change_in_x_wind_due_to_convective_gravity_wave_drag
+  long_name = cumulative change in x wind due to convective gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldv3dt_ngw]
+  standard_name = cumulative_change_in_y_wind_due_to_convective_gravity_wave_drag
+  long_name = cumulative change in y wind due to convective gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[ldt3dt_ngw]
+  standard_name = cumulative_change_in_temperature_due_to_convective_gravity_wave_drag
+  long_name = cumulative change in temperature due to convective gravity wave drag
+  units = K
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dudt_obl]
+  standard_name = tendency_of_x_momentum_due_to_blocking_drag
+  long_name = x momentum tendency from blocking drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dvdt_obl]
+  standard_name = tendency_of_y_momentum_due_to_blocking_drag
+  long_name = y momentum tendency from blocking drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dudt_oss]
+  standard_name = tendency_of_x_momentum_due_to_small_scale_gravity_wave_drag
+  long_name = x momentum tendency from small scale gwd
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dvdt_oss]
+  standard_name = tendency_of_y_momentum_due_to_small_scale_gravity_wave_drag
+  long_name = y momentum tendency from small scale gwd
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dudt_ofd]
+  standard_name = tendency_of_x_momentum_due_to_form_drag
+  long_name = x momentum tendency from form drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dvdt_ofd]
+  standard_name = tendency_of_y_momentum_due_to_form_drag
+  long_name = y momentum tendency from form drag
+  units = m s-2
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = in
+[dws3dt_ogw]
+  standard_name = cumulative_change_in_wind_speed_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative change in wind speed due to mesoscale orographic gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dws3dt_obl]
+  standard_name = cumulative_change_in_wind_speed_due_to_blocking_drag
+  long_name = cumulative change in wind speed due to blocking drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dws3dt_oss]
+  standard_name = cumulative_change_in_wind_speed_due_to_small_scale_orographic_gravity_wave_drag
+  long_name = cumulative change in wind speed due to small scale orographic gravity wave drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dws3dt_ofd]
+  standard_name = cumulative_change_in_wind_speed_due_to_turbulent_orographic_form_drag
+  long_name = cumulative change in wind speed due to turbulent orographic form drag
+  units = m s-1
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  intent = inout
+[du_ogwcol]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = integrated x momentum flux from meso scale ogw
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[dv_ogwcol]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = integrated y momentum flux from meso scale ogw
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[du_oblcol]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_blocking_drag
+  long_name = integrated x momentum flux from blocking drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[dv_oblcol]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_blocking_drag
+  long_name = integrated y momentum flux from blocking drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[du_osscol]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_small_scale_gravity_wave_drag
+  long_name = integrated x momentum flux from small scale gwd
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[dv_osscol]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_small_scale_gravity_wave_drag
+  long_name = integrated y momentum flux from small scale gwd
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[du_ofdcol]
+  standard_name = vertically_integrated_x_momentum_flux_due_to_form_drag
+  long_name = integrated x momentum flux from form drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[dv_ofdcol]
+  standard_name = vertically_integrated_y_momentum_flux_due_to_form_drag
+  long_name = integrated y momentum flux from form drag
+  units = Pa
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
+[du3_ogwcol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative integrated x momentum flux from mesoscale orographic gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dv3_ogwcol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_to_mesoscale_orographic_gravity_wave_drag
+  long_name = cumulative integrated y momentum flux from mesoscale orographic gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[du3_oblcol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_blocking_drag
+  long_name = cumulative integrated x momentum flux from blocking drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dv3_oblcol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_to_blocking_drag
+  long_name = cumulative integrated y momentum flux from blocking drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[du3_osscol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_small_scale_gravity_wave_drag
+  long_name = cumulative integrated x momentum flux from small scale gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dv3_osscol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_small_scale_gravity_wave_drag
+  long_name = cumulative integrated y momentum flux from small scale gravity wave drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[du3_ofdcol]
+  standard_name = cumulative_vertically_integrated_x_momentum_flux_due_to_form_drag
+  long_name = cumulative integrated x momentum flux from form drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
+[dv3_ofdcol]
+  standard_name = cumulative_vertically_integrated_y_momentum_flux_due_to_form_drag
+  long_name = cumulative integrated y momentum flux from form drag
+  units = Pa s
+  dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
   intent = inout

--- a/physics/unified_ugwp_post.meta
+++ b/physics/unified_ugwp_post.meta
@@ -332,48 +332,48 @@
   kind = kind_phys
   intent = inout
 [dudt_obl]
-  standard_name = tendency_of_x_momentum_due_to_blocking_drag
-  long_name = x momentum tendency from blocking drag
+  standard_name = tendency_of_x_wind_due_to_blocking_drag
+  long_name = x wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [dvdt_obl]
-  standard_name = tendency_of_y_momentum_due_to_blocking_drag
-  long_name = y momentum tendency from blocking drag
+  standard_name = tendency_of_y_wind_due_to_blocking_drag
+  long_name = y wind tendency from blocking drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [dudt_oss]
-  standard_name = tendency_of_x_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = x momentum tendency from small scale gwd
+  standard_name = tendency_of_x_wind_due_to_small_scale_gravity_wave_drag
+  long_name = x wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [dvdt_oss]
-  standard_name = tendency_of_y_momentum_due_to_small_scale_gravity_wave_drag
-  long_name = y momentum tendency from small scale gwd
+  standard_name = tendency_of_y_wind_due_to_small_scale_gravity_wave_drag
+  long_name = y wind tendency from small scale gwd
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [dudt_ofd]
-  standard_name = tendency_of_x_momentum_due_to_form_drag
-  long_name = x momentum tendency from form drag
+  standard_name = tendency_of_x_wind_due_to_form_drag
+  long_name = x wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real
   kind = kind_phys
   intent = in
 [dvdt_ofd]
-  standard_name = tendency_of_y_momentum_due_to_form_drag
-  long_name = y momentum tendency from form drag
+  standard_name = tendency_of_y_wind_due_to_form_drag
+  long_name = y wind tendency from form drag
   units = m s-2
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   type = real


### PR DESCRIPTION
This pull request has three main components:
1)  To fix some issues with the orographic drag schemes of the "_drag_suite_" module which have caused model crashes to occur in GFSv17 p8 testing.  These issues are described in [Issue #20](https://github.com/ufs-community/ccpp-physics/issues/20).
2)  To add optional diagnostic outputs for each of the components of the drag suite for tuning purposes.  This is also described in [Issue #20](https://github.com/ufs-community/ccpp-physics/issues/20).  The optional diagnostic outputs can be selected at run time by the already-existing _ldiag_ugwp_ namelist flag.
3)  As part of the 1st component above, at the suggestion of Philip Pegion, we have added the capability to update the u and v winds in each model column based on the tendencies calculated by the mesoscale gravity wave drag and blocking schemes, and using these for the calculation of the tendencies by the small-scale gravity wave drag and turbulent orographic form drag schemes.  This sequential updating of the wind profile has been shown to improve the numerical stability.  The option to update the winds in this manner is controlled by a new logic flag _ugwp_seq_update_, which for now, is not a namelist option, but is hardwired by default to ._false_. in _GFS_typedefs.F90_.  The user can change this to ._true_. at compile time.

The above modifications involve 14 modules in this repo in order to maintain "backwards compatibility" amongst the following CCPP schemes:  _unified_ugwp_, _drag_suite_, _ugwpv1_gsldrag_ and _cires_ugwp_.

RT's and ORT's were conducted on Hera with passing results.  Log files are at:
/scratch1/BMC/wrfruc/mtoy/git_local/ufs-weather-model/tests/RegressionTests_hera.intel.log
/scratch1/BMC/wrfruc/mtoy/git_local/ufs-weather-model/tests/OpnReqTests_control_p8_hera.intel.log

Issue:  [ufs-community/ccpp-physics/#20](https://github.com/ufs-community/ccpp-physics/issues/20)


The added optional diagnostic outputs are:
dws3dt_ogw  -- time-averaged wind speed tendency due to mesoscale gravity wave drag
dws3dt_obl  -- time-averaged wind speed tendency due to blocking drag
dws3dt_oss  -- time-averaged wind speed tendency due to small-scale gravity wave drag
dws3dt_ofd  -- time-averaged wind speed tendency due to turbulent orographic form drag
ldu3dt_ogw  -- time-averaged x wind tendency due to mesoscale orographic gravity wave drag
ldu3dt_obl  -- time-averaged x wind tendency due to blocking drag
ldu3dt_oss  -- time-averaged x wind tendency due to small scale gravity wave drag
ldu3dt_ofd  -- time-averaged x wind tendency due to form drag
ldu3dt_ngw  -- time-averaged u momentum tendency due to non-stationary gravity wave drag
ldv3dt_ngw  -- time-averaged v momentum tendency due to non-stationary gravity wave drag
ldt3dt_ngw  -- time-averaged temperature tendency due to non-stationary gravity wave drag
dudt_ogw  -- instantaneous x wind tendency from mesoscale orographic gravity wave drag
dvdt_ogw  -- instantaneous y wind tendency from mesoscale orographic gravity wave drag
dudt_obl  -- instantaneous x wind tendency from blocking drag
dvdt_obl  -- instantaneous y wind tendency from blocking drag
dudt_oss  -- instantaneous x wind tendency from small scale GWD
dvdt_oss  -- instantaneous y wind tendency from small scale GWD
dudt_ofd  -- instantaneous x wind tendency from form drag
dvdt_ofd  -- instantaneous y wind tendency from form drag
du_ogwcol  -- instantaneous integrated x momentum flux from mesoscale orographic gravity wave drag
dv_ogwcol  -- instantaneous integrated y momentum flux from mesoscale orographic gravity wave drag
du_oblcol  -- instantaneous integrated x momentum flux from blocking drag
dv_oblcol  -- instantaneous integrated y momentum flux from blocking drag
du_osscol  -- instantaneous integrated x momentum flux from small scale gwd
dv_osscol  -- instantaneous integrated y momentum flux from small scale gwd
du_ofdcol  -- instantaneous integrated x momentum flux from form drag
dv_ofdcol  -- instantaneous integrated y momentum flux from form drag
du3_ogwcol  -- time-averaged surface x momentum flux from mesoscale orographic gravity wave drag
dv3_ogwcol  -- time-averaged surface y momentum flux from mesoscale orographic gravity wave drag
du3_oblcol  -- time-averaged surface x momentum flux from blocking drag
dv3_oblcol  -- time-averaged surface y momentum flux from blocking drag
du3_osscol  -- time-averaged surface x momentum flux from small scale gravity wave drag
dv3_osscol  -- time-averaged surface y momentum flux from small scale gravity wave drag
du3_ofdcol  -- time-averaged surface x momentum flux from form drag
dv3_ofdcol  -- time-averaged surface y momentum flux from form drag

Note that the relevant _diag_table_ entries for these variables are included in:
_ufs-weather-model/tests/parm/diag_table/diag_table_rap_
