### PR TITLE
bug fix for hybrid-EDMF PBL scheme

### DIFF
--- a/physics/hedmf.f
+++ b/physics/hedmf.f
@@ -770,7 +770,7 @@ c
 !>  ## Calculate the inverse Prandtl number
 !!  For an unstable PBL, the Prandtl number is calculated according to Hong and Pan (1996) \cite hong_and_pan_1996, equation 10, whereas for a stable boundary layer, the Prandtl number is simply \f$Pr = \frac{\phi_h}{\phi_m}\f$.
       do i = 1, im
-        if(ublflg(i)) then
+        if(pblflg(i)) then
           tem = phih(i)/phim(i)+cfac*vk*sfcfrac
         else
           tem = phih(i)/phim(i)


### PR DESCRIPTION
The conditional statement for calculating the Prandtl number were modified to correctly distinguish the boundary layer stability.
A more detailed description of modification and experiment results can be found in the attach file.
[modified hedmf.pdf](https://github.com/ufs-community/ccpp-physics/files/10370929/modified.hedmf.pdf)
