### PR TITLE
Bug fix for cloud effective radius for convective clouds (HR1)

### DIFF
--- a/physics/radiation_clouds.f
+++ b/physics/radiation_clouds.f
@@ -2212,10 +2212,16 @@
 !>   The total condensate includes convective condensate.
         do k = 1, NLAY-1
           do i = 1, IX
-            cwp(i,k) = max(0.0, (clw(i,k,ntcw)+cnvw(i,k)*
-     &                  (1.-tem2d(i,k))) * gfac * delp(i,k))
-            cip(i,k) = max(0.0, (clw(i,k,ntiw) + cnvw(i,k)*
-     &                  tem2d(i,k)) *gfac * delp(i,k))
+            tem1 = cnvw(i,k)*(1.-tem2d(i,k))
+            cwp(i,k) = max(0.0, (clw(i,k,ntcw)+tem1) *
+     &                 gfac * delp(i,k))
+            if(tem1 > 1.e-12 .and.  clw(i,k,ntcw) < 1.e-12)
+     &                 rew(i,k)=reliq_def
+            tem2 = cnvw(i,k)*tem2d(i,k)
+            cip(i,k) = max(0.0, (clw(i,k,ntiw) + tem2 )
+     &             *gfac * delp(i,k))
+            if(tem2 > 1.e-12 .and.  clw(i,k,ntiw) < 1.e-12)
+     &             rei(i,k)=reice_def
             crp(i,k) = max(0.0, clw(i,k,ntrw) * gfac * delp(i,k))
             csp(i,k) = max(0.0, clw(i,k,ntsw) * gfac * delp(i,k))
           enddo


### PR DESCRIPTION
This is an emergency bug fix for cloud effective radius for convective clouds (Issue[#36](https://github.com/ufs-community/ccpp-physics/issues/36)).  For a temporary solution, 50 micro and 10 micro is assigned to convective cloud ice and liquid, respectively. More physics-based values will be assigned in the future improvement in HR2.  The test results are here.
[GFSv17_highresol_cnvwinradiation_bugfix_in_convective_condensate.pptx](https://github.com/ufs-community/ccpp-physics/files/10504132/GFSv17_highresol_cnvwinradiation_bugfix_in_convective_condensate.pptx)
