### PR TITLE
changes made in surface composite pre - remove use_flake section

### DIFF
--- a/physics/GFS_surface_composites_pre.F90
+++ b/physics/GFS_surface_composites_pre.F90
@@ -239,19 +239,19 @@ contains
       enddo
 
 ! to prepare to separate lake from ocean under water category
-      do i = 1, im
-        if ((wet(i) .or. icy(i)) .and. lakefrac(i) > zero) then
-          lake(i) = .true.
-          if (lkm == 1 .and. lakefrac(i) >= 0.15 .and. lakedepth(i) > one) then
-            use_flake(i) = .true.
-          else
-            use_flake(i) = .false.
-          endif
-        else
-          lake(i) = .false.
-          use_flake(i) = .false.
-        endif
-      enddo
+!      do i = 1, im
+!        if ((wet(i) .or. icy(i)) .and. lakefrac(i) > zero) then
+!          lake(i) = .true.
+!          if (lkm == 1 .and. lakefrac(i) >= 0.15 .and. lakedepth(i) > one) then
+!            use_flake(i) = .true.
+!          else
+!            use_flake(i) = .false.
+!          endif
+!        else
+!          lake(i) = .false.
+!          use_flake(i) = .false.
+!        endif
+!      enddo
 !
       if (frac_grid) then
         do i=1,im


### PR DESCRIPTION
Removing flake model from ccpp/physics
the Variables used in the flakes related code are use_flake, lkm, lake mainly. 
Small code removal for lake and followed by RT test.
RT test compared with baseline results to make sure that nothing changes removing flake related code.
GFS_surface_composites_pre.F90
removed flake code 241-251 ln. 
RT test done and looks fine. 

