### PR TITLE
Ufs/dev ugwp stoch phys fix

### DIFF
--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -9,6 +9,12 @@
 !> \defgroup gfs_drag_suite_mod GSL drag_suite Module
 !> This module contains the CCPP-compliant GSL orographic gravity wave drag scheme.
 !> @{
+!!
+!> \brief This subroutine initializes the orographic gravity wave drag scheme.
+!!
+!> \section arg_table_drag_suite_init Argument Table
+!! \htmlinclude drag_suite_init.html
+!!
       subroutine drag_suite_init(gwd_opt, errmsg, errflg)
 
       integer,          intent(in)  :: gwd_opt

--- a/physics/drag_suite.F90
+++ b/physics/drag_suite.F90
@@ -9,12 +9,6 @@
 !> \defgroup gfs_drag_suite_mod GSL drag_suite Module
 !> This module contains the CCPP-compliant GSL orographic gravity wave drag scheme.
 !> @{
-!!
-!> \brief This subroutine initializes the orographic gravity wave drag scheme.
-!!
-!> \section arg_table_drag_suite_init Argument Table
-!! \htmlinclude drag_suite_init.html
-!!
       subroutine drag_suite_init(gwd_opt, errmsg, errflg)
 
       integer,          intent(in)  :: gwd_opt
@@ -342,7 +336,7 @@
    real(kind=kind_phys), intent(inout) ::                        &
      &                   dudt(:,:),dvdt(:,:),                &
      &                   dtdt(:,:)
-   real(kind=kind_phys), intent(out) :: rdxzb(:)
+   real(kind=kind_phys), intent(inout) :: rdxzb(:)
    real(kind=kind_phys), intent(in) ::                           &
      &                            u1(:,:),v1(:,:),           &
      &                            t1(:,:),q1(:,:),           &
@@ -605,7 +599,6 @@
       else
          xland(i)=2.0
       endif
-      RDXZB(i)  = 0.0
    enddo
 
 !--- calculate scale-aware tapering factors
@@ -817,6 +810,8 @@ IF ( (do_gsl_drag_ls_bl).and.                            &
      (gwd_opt_ms.or.gwd_opt_bl) ) then
 
    do i=its,im
+
+      RDXZB(i)  = 0.0
 
       if ( ls_taper(i).GT.1.E-02 ) then
 

--- a/physics/drag_suite.meta
+++ b/physics/drag_suite.meta
@@ -536,7 +536,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [dx]
   standard_name = characteristic_grid_lengthscale
   long_name = size of the grid cell


### PR DESCRIPTION
This PR fixes a bug that occurs when running stochastic physics.  As part of ccpp-physics [PR#22](https://github.com/ufs-community/ccpp-physics/pull/22), the order in which subroutines "gwdps_run" and "drag_suite_run" were called by subroutine "unified_ugwp_run" was reversed.  Subroutine "drag_suite_run" is called last, but the variable "RDXZB" (the level of the dividing streamline for blocking) is initialized, which zeros out the value that was calculated in "gwdps_run".  RDXZB is needed outside of the unified_ugwp subroutine by stochastic physics.  This caused stochastic physics runs to crash.  The bug was not caught by regression testing.

The problem has been fixed by changing the declaration of "RDXZB" from "intent(out)" to "intent(inout)" in drag_suite.F90 and drag_suite.meta, and initializing it in drag_suite.F90 only when the GSL drag suite blocking is performed, i.e., when "do_gsl_drag_ls_bl" is equal to .true.

The stochastic physics team (@pjpegion et al) has tested the revised code, and the crashes no longer occur.  Regression tests and ORT's have passed (Hera -- Intel) with no changes to the baseline.

This PR fixes [Issue #62](https://github.com/ufs-community/ccpp-physics/issues/62). 

This fix needs to be done for running the GEFS.v13 reanalysis and reforecasts.
