### PR TITLE
Increase optimization for ugwp_driver_v0.F

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,12 @@ if(${LOCAL_CURRENT_SOURCE_DIR}/physics/rte-rrtmgp/rrtmgp/kernels/mo_gas_optics_k
                               APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS} -O1")
 endif()
 
+# Increase optimization for ugwp_driver_v0.F
+if(CMAKE_BUILD_TYPE STREQUAL "Release" AND ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
+  SET_SOURCE_FILES_PROPERTIES(${LOCAL_CURRENT_SOURCE_DIR}/physics/ugwp_driver_v0.F
+                              APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_Fortran_FLAGS_PHYSICS} -fp-model=fast -fprotect-parens -fimf-precision=high")
+endif()
+
 #------------------------------------------------------------------------------
 
 add_library(ccpp_physics STATIC ${SCHEMES} ${SCHEMES_OPENMP_OFF} ${SCHEMES_DYNAMICS} ${CAPS})


### PR DESCRIPTION
Performance profiling of a HAFS case on NOAA systems revealed significant of time was spent in subroutine fv3_ugwp_solv2_v0().  This pull request (PR) allows the compiler to fully optimize this routine while maintaining round-off level differences.

How Has This Been Tested?
My testing includes the creation of an offline driver for fv3_ugwp_solv2_v0().  I extracted full volume (all ranks and threads) inputs to and outputs from fv3_ugwp_solv2_v0() at time step 290 (5.8 hours) into a HAFS case.  The offline driver feeds the saved inputs into fv3_ugwp_solv2_v0() and compares the output against the saved ground truth.  The driver gives zero-diff output when compiled with the flags used in production.

I found a set of compile options that allows the fv3_ugwp_solv2_v0() to run more than 2x faster than the baseline yet gives absolute differences of +- e-14.  Numerical stats attached as ugwp_results.txt.

[ugwp_results.txt](https://github.com/ufs-community/ccpp-physics/files/11593674/ugwp_results.txt)

The driver and associated input and output files are located at
alogin02:/lfs/h1/hpc/support/daniel.kokron/HAFS/hafsv1_final/T2O_2020092200_17L/UGWPsolv2V0/driver.f90
alogin02:/lfs/h1/hpc/support/daniel.kokron/HAFS/hafsv1_final/T2O_2020092200_17L/UGWPsolv2V0/IO

This PR is a non zero-diff change, so the baseline will need to be regenerated.

I ran the rt.sh suite on acorn and cactus using the "-c" option then again with "-m".  The logs from both runs on both machines indicated "REGRESSION TEST WAS SUCCESSFUL"

Performance metric:
Add up the phase1 and phase2 timings printed in the output listing
grep PASS stdout | awk '{t+=$10;print t}' | tail -1
The units are seconds.

I ran a 126-hour simulation on acorn using a 26-node case.
acorn:/lfs/h1/hpc/support/daniel.kokron/HAFS/hafsv1_final/T2O_2020092200_17L

| Trial | Baseline | Optimized
| -------------- | ------------ | ----------- |
| 1 | 7881 | 7489 |
| 2 | 7866.7 | 7529.6 |
| 3 | 7865.7 | 7488.4 |
| 4 | 7849.9 | 7464.7 |
| 5 | 7851.7 | 7509.3 |
| 6 | 7877.1 | 7499.2 |
| Mean | 7865.4 | 7496.7 |

I also ran a 24-hour simulation on cactus using a 47-node case provided to me by Bin Liu
cactus:/lfs/h2/emc/ptmp/bin.liu/hafsv1_merge_hfsb/2021082712/09L/forecast

The units are seconds.
| Trial | Baseline | Optimized
| -------------- | ------------ | ----------- |
| 1 | 984.975 | 984.944 |
| 2 | 987.563 | 917.817 |
| 3 | 986.981 | 948.971 |
| 4 | 999.552 | 935.908 |
| 5 | 1006.71 | 918.378 |
| 6 | 985.828 | 940.994 |
| 7 | 1000.54 | 935.985 |
| Mean | 993.2 | 940.4 |

Based on these timings, I expect savings from this PR of ~(52.8s)*5=264 seconds for a full 5-day simulation.