### PR TITLE
Fixes to allow FV3_HRRR_c3 to run with gnu debug plus PR #113, #106, and #103

### DIFF
--- a/physics/GFS_phys_time_vary.fv3.F90
+++ b/physics/GFS_phys_time_vary.fv3.F90
@@ -67,14 +67,14 @@
         integer, intent(in) :: myerrflg
         character(*), intent(out) :: errmsg
         integer, intent(inout) :: errflg
-        if(myerrflg == 0) return
-        if(errflg /= 0) return
-        !$OMP CRITICAL
-        if(errflg == 0) then
-          errmsg = myerrmsg
-          errflg = myerrflg
+        if(myerrflg /= 0 .and. errflg == 0) then
+          !$OMP CRITICAL
+          if(errflg == 0) then
+            errmsg = myerrmsg
+            errflg = myerrflg
+          endif
+          !$OMP END CRITICAL
         endif
-        !$OMP END CRITICAL
       end subroutine copy_error
 
 !> \section arg_table_GFS_phys_time_vary_init Argument Table
@@ -209,7 +209,7 @@
          real(kind=kind_phys), dimension(:), allocatable :: dzsnso
 
          integer :: myerrflg
-         character(255) :: myerrmsg
+         character(len=255) :: myerrmsg
 
          ! Initialize CCPP error handling variables
          errmsg = ''
@@ -288,6 +288,7 @@
          if (iaerclm) then
            ntrcaer = ntrcaerm
            myerrflg = 0
+           myerrmsg = 'read_aerdata failed without a message'
            call read_aerdata (me,master,iflip,idate,myerrmsg,myerrflg)
            call copy_error(myerrmsg, myerrflg, errmsg, errflg)
          else if(iaermdl ==2 ) then
@@ -315,6 +316,7 @@
 !> - Call tau_amf dats for  ugwp_v1
          if (do_ugwp_v1) then
             myerrflg = 0
+            myerrmsg = 'read_tau_amf failed without a message'
             call read_tau_amf(me, master, myerrmsg, myerrflg)
             call copy_error(myerrmsg, myerrflg, errmsg, errflg)
          endif
@@ -322,12 +324,14 @@
 !$OMP section
 !> - Initialize soil vegetation (needed for sncovr calculation further down)
          myerrflg = 0
+         myerrmsg = 'set_soilveg failed without a message'
          call set_soilveg(me, isot, ivegsrc, nlunit, myerrmsg, myerrflg)
          call copy_error(myerrmsg, myerrflg, errmsg, errflg)
 
 !$OMP section
 !> - read in NoahMP table (needed for NoahMP init)
          myerrflg = 0
+         myerrmsg = 'read_mp_table_parameters failed without a message'
          call read_mp_table_parameters(myerrmsg, myerrflg)
          call copy_error(myerrmsg, myerrflg, errmsg, errflg)
 

--- a/physics/GFS_phys_time_vary.fv3.F90
+++ b/physics/GFS_phys_time_vary.fv3.F90
@@ -226,7 +226,7 @@
 !$OMP          shared (xlat_d,xlon_d,imap,jmap,errmsg,errflg)                       &
 !$OMP          shared (levozp,oz_coeff,oz_pres,ozpl)                                &
 !$OMP          shared (levh2o,h2o_coeff,h2o_pres,h2opl)                             &
-!$OMP          shared (iamin, iamax, jamin, jamax)                                  &
+!$OMP          shared (iamin, iamax, jamin, jamax, lsm_noahmp)                      &
 !$OMP          shared (iaerclm,iaermdl,ntrcaer,aer_nm,iflip,iccn)                   &
 !$OMP          shared (jindx1_o3,jindx2_o3,ddy_o3,jindx1_h,jindx2_h,ddy_h)          &
 !$OMP          shared (jindx1_aer,jindx2_aer,ddy_aer,iindx1_aer,iindx2_aer,ddx_aer) &
@@ -240,6 +240,7 @@
 
 !$OMP section
 !> - Call read_o3data() to read ozone data
+       need_o3data: if(ntoz > 0) then
          call read_o3data (ntoz, me, master)
 
          ! Consistency check that the hardcoded values for levozp and
@@ -259,9 +260,11 @@
                   oz_coeff, " /= ", size(ozpl, dim=3)
             call copy_error(myerrmsg, myerrflg, errmsg, errflg)
          end if
+       endif need_o3data
 
 !$OMP section
 !> - Call read_h2odata() to read stratospheric water vapor data
+       need_h2odata: if(h2o_phys) then
          call read_h2odata (h2o_phys, me, master)
 
          ! Consistency check that the hardcoded values for levh2o and
@@ -281,6 +284,7 @@
             myerrflg = 1
             call copy_error(myerrmsg, myerrflg, errmsg, errflg)
          end if
+       endif need_h2odata
 
 !$OMP section
 !> - Call read_aerdata() to read aerosol climatology, Anning added coupled
@@ -330,10 +334,12 @@
 
 !$OMP section
 !> - read in NoahMP table (needed for NoahMP init)
-         myerrflg = 0
-         myerrmsg = 'read_mp_table_parameters failed without a message'
-         call read_mp_table_parameters(myerrmsg, myerrflg)
-         call copy_error(myerrmsg, myerrflg, errmsg, errflg)
+         if(lsm == lsm_noahmp) then
+           myerrflg = 0
+           myerrmsg = 'read_mp_table_parameters failed without a message'
+           call read_mp_table_parameters(myerrmsg, myerrflg)
+           call copy_error(myerrmsg, myerrflg, errmsg, errflg)
+         endif
 
 !$OMP end sections
 

--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -976,7 +976,7 @@
      &       imp_physics_mg, iovr, iovr_rand, iovr_maxrand, iovr_max,   &
      &       iovr_dcorr, iovr_exp, iovr_exprand, idcor, idcor_con,      &
      &       idcor_hogan, idcor_oreopoulos, lcrick, lcnorm,             &
-     &       imfdeepcnv, imfdeepcnv_gf, imfdeepcnv_gf, do_mynnedmf,     &
+     &       imfdeepcnv, imfdeepcnv_gf, imfdeepcnv_c3, do_mynnedmf,     &
      &       lgfdlmprad,                                                &
      &       uni_cld, lmfshal, lmfdeep2, cldcov, clouds1,               &
      &       effrl, effri, effrr, effrs, effr_in,                       &

--- a/physics/clm_lake.f90
+++ b/physics/clm_lake.f90
@@ -554,6 +554,19 @@ MODULE clm_lake
              dz_lake(c,:) = z_lake(1,:)
            enddo
 
+           ! Soil hydraulic and thermal properties
+           isl = ISLTYP(i)   
+           if (isl == 0  ) isl = 14
+           if (isl == 14 ) isl = isl + 1 
+
+           watsat = 0.489_kind_lake - 0.00126_kind_lake*sand(isl)
+           csol   = (2.128_kind_lake*sand(isl)+2.385_kind_lake*clay(isl)) / (sand(isl)+clay(isl))*1.e6_kind_lake  ! J/(m3 K)
+           tkm    = (8.80_kind_lake*sand(isl)+2.92_kind_lake*clay(isl))/(sand(isl)+clay(isl))          ! W/(m K)
+           bd     = (1._kind_lake-watsat(1,1))*2.7e3_kind_lake
+           tkmg   = tkm ** (1._kind_lake- watsat(1,1))
+           tkdry  = (0.135_kind_lake*bd + 64.7_kind_lake) / (2.7e3_kind_lake - 0.947_kind_lake*bd)
+           tksatu = tkmg(1,1)*0.57_kind_lake**watsat(1,1)
+
            do c = 1,column
      
             forc_t(c)          = SFCTMP           ! [K]
@@ -593,21 +606,6 @@ MODULE clm_lake
             do k = -nlevsnow+0,nlevsoil
                zi(c,k)            = zi3d(i,k)
             enddo
-            do k = 1,nlevsoil
-               ! Soil hydraulic and thermal properties
-               isl = ISLTYP(i)   
-               if (isl == 0  ) isl = 14
-               if (isl == 14 ) isl = isl + 1 
-
-               watsat(c,k) = 0.489_kind_lake - 0.00126_kind_lake*sand(isl)
-               csol(c,k) = (2.128_kind_lake*sand(isl)+2.385_kind_lake*clay(isl)) / (sand(isl)+clay(isl))*1.e6_kind_lake  ! J/(m3 K)
-               tkm                = (8.80_kind_lake*sand(isl)+2.92_kind_lake*clay(isl))/(sand(isl)+clay(isl))          ! W/(m K)
-               bd                 = (1._kind_lake-watsat(c,k))*2.7e3_kind_lake
-               tkmg(c,k)          = tkm ** (1._kind_lake- watsat(c,k))
-               tkdry(c,k)         = (0.135_kind_lake*bd + 64.7_kind_lake) / (2.7e3_kind_lake - 0.947_kind_lake*bd)
-               tksatu(c,k)        = tkmg(c,k)*0.57_kind_lake**watsat(c,k)
-            enddo
-            
           enddo
 
           eflx_lwrad_net = -9999

--- a/physics/clm_lake.f90
+++ b/physics/clm_lake.f90
@@ -551,7 +551,7 @@ MODULE clm_lake
 
            do c = 2,column
              z_lake(c,:) = z_lake(1,:)
-             dz_lake(c,:) = z_lake(1,:)
+             dz_lake(c,:) = dz_lake(1,:)
            enddo
 
            ! Soil hydraulic and thermal properties

--- a/physics/clm_lake.f90
+++ b/physics/clm_lake.f90
@@ -229,6 +229,31 @@ MODULE clm_lake
  
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+    subroutine calculate_z_dz_lake(i,input_lakedepth,clm_lakedepth,z_lake,dz_lake)
+      implicit none
+      integer, intent(in) :: i
+      real(kind_phys), intent(inout) :: clm_lakedepth(:) ! lake depth used by clm
+      real(kind_phys), intent(in) :: input_lakedepth(:) ! lake depth before correction (m)
+      real(kind_lake) :: z_lake(nlevlake)  ! layer depth for lake (m)
+      real(kind_lake) :: dz_lake(nlevlake) ! layer thickness for lake (m)
+      real(kind_lake) :: depthratio
+
+      if (input_lakedepth(i) == spval) then
+        clm_lakedepth(i) = zlak(nlevlake) + 0.5_kind_lake*dzlak(nlevlake)
+        z_lake(1:nlevlake) = zlak(1:nlevlake)
+        dz_lake(1:nlevlake) = dzlak(1:nlevlake)
+      else
+        depthratio = input_lakedepth(i) / (zlak(nlevlake) + 0.5_kind_lake*dzlak(nlevlake)) 
+        z_lake(1) = zlak(1)
+        dz_lake(1) = dzlak(1)
+        dz_lake(2:nlevlake) = dzlak(2:nlevlake)*depthratio
+        z_lake(2:nlevlake) = zlak(2:nlevlake)*depthratio + dz_lake(1)*(1._kind_lake - depthratio)
+      end if
+
+    end subroutine calculate_z_dz_lake
+
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
     !> \section arg_table_clm_lake_run Argument Table
     !! \htmlinclude clm_lake_run.html
     !!
@@ -258,8 +283,8 @@ MODULE clm_lake
 
          salty, savedtke12d, snowdp2d, h2osno2d, snl2d, t_grnd2d, t_lake3d,       &
          lake_icefrac3d, t_soisno3d, h2osoi_ice3d, h2osoi_liq3d, h2osoi_vol3d,    &
-         z3d, dz3d, zi3d, z_lake3d, dz_lake3d, watsat3d, csol3d, sand3d, clay3d,  &
-         tkmg3d, tkdry3d, tksatu3d, clm_lakedepth, cannot_freeze,                 &
+         z3d, dz3d, zi3d,                                                         &
+                   input_lakedepth, clm_lakedepth, cannot_freeze,                 &
 
          ! Error reporting:
          errflg, errmsg)
@@ -336,14 +361,8 @@ MODULE clm_lake
                                                                                   dz3d 
     real(kind_phys),    dimension( :,-nlevsnow+0: )  ,INTENT(inout)  :: zi3d    
 
-    REAL(KIND_PHYS),           DIMENSION( :,: ),INTENT(INOUT)  :: z_lake3d
-    REAL(KIND_PHYS),           DIMENSION( :,: ),INTENT(INOUT)  :: dz_lake3d
-    REAL(KIND_PHYS),           DIMENSION( :,: ),INTENT(INOUT)  :: watsat3d
-    REAL(KIND_PHYS),           DIMENSION( :,: ),INTENT(INOUT)  :: csol3d, sand3d, clay3d
-    REAL(KIND_PHYS),           DIMENSION( :,: ),INTENT(INOUT)  :: tkmg3d
-    REAL(KIND_PHYS),           DIMENSION( :,: ),INTENT(INOUT)  :: tkdry3d
-    REAL(KIND_PHYS),           DIMENSION( :,: ),INTENT(INOUT)  :: tksatu3d
     REAL(KIND_PHYS),           DIMENSION( : )  ,INTENT(INOUT)  :: clm_lakedepth
+    REAL(KIND_PHYS),           DIMENSION( : )  ,INTENT(INOUT)  :: input_lakedepth
 
     !
     ! Error reporting:
@@ -430,10 +449,10 @@ MODULE clm_lake
       character*255 :: message
       logical, parameter :: feedback_to_atmosphere = .true. ! FIXME: REMOVE
 
-      real(kind_lake) :: to_radians, lat_d, lon_d, qss
+      real(kind_lake) :: to_radians, lat_d, lon_d, qss, tkm, bd
 
-      integer :: month,num1,num2,day_of_month
-      real(kind_lake) :: wght1,wght2,Tclim
+      integer :: month,num1,num2,day_of_month,isl
+      real(kind_lake) :: wght1,wght2,Tclim,depthratio
 
       logical salty_flag, cannot_freeze_flag
 
@@ -451,29 +470,17 @@ MODULE clm_lake
                               lakedepth_default=lakedepth_default, fhour=fhour,           &
              oro_lakedepth=oro_lakedepth, savedtke12d=savedtke12d, snowdp2d=snowdp2d,     &
              h2osno2d=h2osno2d, snl2d=snl2d, t_grnd2d=t_grnd2d, t_lake3d=t_lake3d,        &
-             lake_icefrac3d=lake_icefrac3d, z_lake3d=z_lake3d, dz_lake3d=dz_lake3d,       &
+             lake_icefrac3d=lake_icefrac3d,                                               &
              t_soisno3d=t_soisno3d, h2osoi_ice3d=h2osoi_ice3d, h2osoi_liq3d=h2osoi_liq3d, &
-             h2osoi_vol3d=h2osoi_vol3d, z3d=z3d, dz3d=dz3d, zi3d=zi3d, watsat3d=watsat3d, &
-             csol3d=csol3d, tkmg3d=tkmg3d, fice=fice, hice=hice, min_lakeice=min_lakeice, &
+             h2osoi_vol3d=h2osoi_vol3d, z3d=z3d, dz3d=dz3d, zi3d=zi3d,                    &
+                                           fice=fice, hice=hice, min_lakeice=min_lakeice, &
              tsfc=tsfc,                                                                   &
-             use_lake_model=use_lake_model, use_lakedepth=use_lakedepth, tkdry3d=tkdry3d, &
-             tksatu3d=tksatu3d, im=im, prsi=prsi, xlat_d=xlat_d, xlon_d=xlon_d,           &
-             clm_lake_initialized=clm_lake_initialized, sand3d=sand3d, clay3d=clay3d,     &
+             use_lake_model=use_lake_model, use_lakedepth=use_lakedepth,                  &
+                                im=im, prsi=prsi, xlat_d=xlat_d, xlon_d=xlon_d,           &
+             clm_lake_initialized=clm_lake_initialized, input_lakedepth=input_lakedepth,  &
              tg3=tg3, clm_lakedepth=clm_lakedepth, km=km, me=me, master=master,           &
              errmsg=errmsg, errflg=errflg)
         if(errflg/=0) then
-          return
-        endif
-        if(any(clay3d>0 .and. clay3d<1)) then
-          write(message,*) 'Invalid clay3d. Abort.'
-          errmsg=trim(message)
-          errflg=1
-          return
-        endif
-        if(any(dz_lake3d>0 .and. dz_lake3d<.1)) then
-          write(message,*) 'Invalid dz_lake3d. Abort.'
-          errmsg=trim(message)
-          errflg=1
           return
         endif
 
@@ -540,6 +547,13 @@ MODULE clm_lake
 
            lake_points = lake_points+1
 
+           call calculate_z_dz_lake(i,input_lakedepth,clm_lakedepth,z_lake(1,:),dz_lake(1,:))
+
+           do c = 2,column
+             z_lake(c,:) = z_lake(1,:)
+             dz_lake(c,:) = z_lake(1,:)
+           enddo
+
            do c = 1,column
      
             forc_t(c)          = SFCTMP           ! [K]
@@ -567,8 +581,6 @@ MODULE clm_lake
             do k = 1,nlevlake
                t_lake(c,k)        = t_lake3d(i,k)
                lake_icefrac(c,k)  = lake_icefrac3d(i,k)
-               z_lake(c,k)        = z_lake3d(i,k)
-               dz_lake(c,k)       = dz_lake3d(i,k)
             enddo
             do k = -nlevsnow+1,nlevsoil
                t_soisno(c,k)      = t_soisno3d(i,k)
@@ -582,11 +594,18 @@ MODULE clm_lake
                zi(c,k)            = zi3d(i,k)
             enddo
             do k = 1,nlevsoil
-               watsat(c,k)        = watsat3d(i,k)
-               csol(c,k)          = csol3d(i,k)
-               tkmg(c,k)          = tkmg3d(i,k)
-               tkdry(c,k)         = tkdry3d(i,k)
-               tksatu(c,k)        = tksatu3d(i,k)
+               ! Soil hydraulic and thermal properties
+               isl = ISLTYP(i)   
+               if (isl == 0  ) isl = 14
+               if (isl == 14 ) isl = isl + 1 
+
+               watsat(c,k) = 0.489_kind_lake - 0.00126_kind_lake*sand(isl)
+               csol(c,k) = (2.128_kind_lake*sand(isl)+2.385_kind_lake*clay(isl)) / (sand(isl)+clay(isl))*1.e6_kind_lake  ! J/(m3 K)
+               tkm                = (8.80_kind_lake*sand(isl)+2.92_kind_lake*clay(isl))/(sand(isl)+clay(isl))          ! W/(m K)
+               bd                 = (1._kind_lake-watsat(c,k))*2.7e3_kind_lake
+               tkmg(c,k)          = tkm ** (1._kind_lake- watsat(c,k))
+               tkdry(c,k)         = (0.135_kind_lake*bd + 64.7_kind_lake) / (2.7e3_kind_lake - 0.947_kind_lake*bd)
+               tksatu(c,k)        = tkmg(c,k)*0.57_kind_lake**watsat(c,k)
             enddo
             
           enddo
@@ -747,7 +766,7 @@ MODULE clm_lake
                   hice(I) = 0                               ! sea_ice_thickness
                   do k=1,nlevlake
                     if(lake_icefrac3d(i,k)>0) then
-                      hice(i) = hice(i) + dz_lake3d(i,k)
+                      hice(i) = hice(i) + dz_lake(c,k)
                     endif
                   end do
                 else ! Not an ice point
@@ -5315,14 +5334,14 @@ if_pergro: if (PERGRO) then
                     weasd,                           lakedepth_default,  fhour,       &
                     oro_lakedepth,  savedtke12d,     snowdp2d,        h2osno2d,       & !o
                     snl2d,          t_grnd2d,        t_lake3d,        lake_icefrac3d, &
-                    z_lake3d,       dz_lake3d,       t_soisno3d,      h2osoi_ice3d,   &
+                                                     t_soisno3d,      h2osoi_ice3d,   &
                     h2osoi_liq3d,   h2osoi_vol3d,    z3d,             dz3d,           &
-                    zi3d,           watsat3d,        csol3d,          tkmg3d,         &
+                    zi3d,                                                             &
                     fice,           hice,            min_lakeice,     tsfc,           &
                     use_lake_model, use_lakedepth,                                    &
-                    tkdry3d,        tksatu3d,        im,              prsi,           &
+                                                     im,              prsi,           &
                     xlat_d,         xlon_d,          clm_lake_initialized,            &
-                    sand3d,         clay3d,          tg3,             clm_lakedepth,  &
+                    input_lakedepth,                 tg3,             clm_lakedepth,  &
                     km,   me,       master,          errmsg,          errflg)
 
    !> Some fields in lakeini are not available during initialization,
@@ -5360,6 +5379,7 @@ if_pergro: if (PERGRO) then
   real(kind_phys),    intent(in)                                      :: lakedepth_default
 
   real(kind_phys),    dimension(IM),intent(inout)                      :: clm_lakedepth
+  real(kind_phys),    dimension(IM),intent(inout)                      :: input_lakedepth
   real(kind_phys),    dimension(IM),intent(in)                         :: oro_lakedepth
   real(kind_phys),    dimension(IM),intent(out)                        :: savedtke12d
   real(kind_phys),    dimension(IM),intent(out)                        :: snowdp2d,       &
@@ -5368,43 +5388,24 @@ if_pergro: if (PERGRO) then
                                                                              t_grnd2d
                                                                               
   real(kind_phys),    dimension(IM,nlevlake),INTENT(out)                  :: t_lake3d,       &
-                                                                             lake_icefrac3d, &
-                                                                             z_lake3d,       &
-                                                                             dz_lake3d
+                                                                             lake_icefrac3d
   real(kind_phys),    dimension(IM,-nlevsnow+1:nlevsoil ),INTENT(out)     :: t_soisno3d,     &
                                                                              h2osoi_ice3d,   &
                                                                              h2osoi_liq3d,   &
                                                                              h2osoi_vol3d,   &
                                                                              z3d,            &
                                                                              dz3d
-  real(kind_phys),    dimension(IM,nlevsoil),INTENT(out)                  :: watsat3d,       &
-                                                                             csol3d,         &
-                                                                             tkmg3d,         &
-                                                                             tkdry3d,        &
-                                                                             tksatu3d
-  real(kind_phys),    dimension(IM,nlevsoil),INTENT(inout)                :: clay3d,   &
-                                                                             sand3d   
 
   real(kind_phys),    dimension( IM,-nlevsnow+0:nlevsoil ),INTENT(out)   :: zi3d            
 
   !LOGICAL, DIMENSION( : ),intent(out)                      :: lake
   !REAL(KIND_PHYS), OPTIONAL,    DIMENSION( : ), INTENT(IN)    ::  lake_depth ! no separate variable for this in CCPP
 
-  real(kind_lake),   dimension( 1:im,1:nlevsoil )     :: bsw3d,    &
-                                                        bsw23d,   &
-                                                        psisat3d, &
-                                                        vwcsat3d, &
-                                                        watdry3d, &
-                                                        watopt3d, &
-                                                        hksat3d,  &
-                                                        sucsat3d
   integer  :: n,i,j,k,ib,lev,bottom      ! indices
   real(kind_lake),dimension(1:im )    :: bd2d               ! bulk density of dry soil material [kg/m^3]
   real(kind_lake),dimension(1:im )    :: tkm2d              ! mineral conductivity
   real(kind_lake),dimension(1:im )    :: xksat2d            ! maximum hydraulic conductivity of soil [mm/s]
   real(kind_lake),dimension(1:im )    :: depthratio2d       ! ratio of lake depth to standard deep lake depth 
-  real(kind_lake),dimension(1:im )    :: clay2d             ! temporary
-  real(kind_lake),dimension(1:im )    :: sand2d             ! temporary
 
   logical,parameter        :: arbinit = .false.
   real(kind_lake),parameter           :: defval  = -999.0
@@ -5413,16 +5414,19 @@ if_pergro: if (PERGRO) then
   character*256 :: message
   real(kind_lake) :: ht
   real(kind_lake) :: rhosn
-  real(kind_lake) :: depth
+  real(kind_lake) :: depth, lakedepth
 
   logical :: climatology_limits
+
+  real(kind_lake)  :: z_lake(nlevlake)  ! layer depth for lake (m)
+  real(kind_lake)  :: dz_lake(nlevlake)                  ! layer thickness for lake (m)
 
   integer, parameter :: xcheck=38
   integer, parameter :: ycheck=92
 
   integer :: used_lakedepth_default, init_points, month, julday
   integer :: mon, iday, num2, num1, juld, day2, day1, wght1, wght2
-  real(kind_lake) :: Tclim
+  real(kind_lake) :: Tclim, watsat
 
   used_lakedepth_default=0
 
@@ -5456,6 +5460,8 @@ if_pergro: if (PERGRO) then
       cycle
     endif
 
+    input_lakedepth=clm_lakedepth
+
     snl2d(i)                   = defval
     do k = -nlevsnow+1,nlevsoil
         h2osoi_liq3d(i,k)      = defval
@@ -5468,8 +5474,6 @@ if_pergro: if (PERGRO) then
     do k = 1,nlevlake 
         t_lake3d(i,k)          = defval
         lake_icefrac3d(i,k)    = defval
-        z_lake3d(i,k)          = defval
-        dz_lake3d(i,k)         = defval
     enddo
     
     if (use_lake_model(i) == 1) then
@@ -5499,60 +5503,9 @@ if_pergro: if (PERGRO) then
     isl = ISLTYP(i)   
     if (isl == 0  ) isl = 14
     if (isl == 14 ) isl = isl + 1 
-    do k = 1,nlevsoil
-      sand3d(i,k)  = sand(isl)
-      clay3d(i,k)  = clay(isl)
 
-      ! Cannot continue if either of these checks fail.
-      if(clay3d(i,k)>0 .and. clay3d(i,k)<1) then
-        write(message,*) 'bad clay3d ',clay3d(i,k)
-        write(0,'(A)') trim(message)
-        errmsg = trim(message)
-        errflg = 1
-        return
-      endif
-      if(sand3d(i,k)>0 .and. sand3d(i,k)<1) then
-        write(message,*) 'bad sand3d ',sand3d(i,k)
-        write(0,'(A)') trim(message)
-        errmsg = trim(message)
-        errflg = 1
-        return
-      endif
-    enddo
+    call calculate_z_dz_lake(i,input_lakedepth,clm_lakedepth,z_lake,dz_lake)
 
-    do k = 1,nlevsoil
-      clay2d(i) = clay3d(i,k)
-      sand2d(i) = sand3d(i,k)
-      watsat3d(i,k) = 0.489_kind_lake - 0.00126_kind_lake*sand2d(i)
-      bd2d(i)    = (1._kind_lake-watsat3d(i,k))*2.7e3_kind_lake
-      xksat2d(i) = 0.0070556_kind_lake *( 10._kind_lake**(-0.884_kind_lake+0.0153_kind_lake*sand2d(i)) ) ! mm/s
-      tkm2d(i) = (8.80_kind_lake*sand2d(i)+2.92_kind_lake*clay2d(i))/(sand2d(i)+clay2d(i))          ! W/(m K)
-
-      bsw3d(i,k) = 2.91_kind_lake + 0.159_kind_lake*clay2d(i)
-      bsw23d(i,k) = -(3.10_kind_lake + 0.157_kind_lake*clay2d(i) - 0.003_kind_lake*sand2d(i))
-      psisat3d(i,k) = -(exp((1.54_kind_lake - 0.0095_kind_lake*sand2d(i) + 0.0063_kind_lake*(100.0_kind_lake-sand2d(i)  &
-           -clay2d(i)))*log(10.0_kind_lake))*9.8e-5_kind_lake)
-      vwcsat3d(i,k) = (50.5_kind_lake - 0.142_kind_lake*sand2d(i) - 0.037_kind_lake*clay2d(i))/100.0_kind_lake
-      hksat3d(i,k) = xksat2d(i)
-      sucsat3d(i,k) = 10._kind_lake * ( 10._kind_lake**(1.88_kind_lake-0.0131_kind_lake*sand2d(i)) )
-      tkmg3d(i,k) = tkm2d(i) ** (1._kind_lake- watsat3d(i,k))
-      tksatu3d(i,k) = tkmg3d(i,k)*0.57_kind_lake**watsat3d(i,k)
-      tkdry3d(i,k) = (0.135_kind_lake*bd2d(i) + 64.7_kind_lake) / (2.7e3_kind_lake - 0.947_kind_lake*bd2d(i))
-      csol3d(i,k) = (2.128_kind_lake*sand2d(i)+2.385_kind_lake*clay2d(i)) / (sand2d(i)+clay2d(i))*1.e6_kind_lake  ! J/(m3 K)
-      watdry3d(i,k) = watsat3d(i,k) * (316230._kind_lake/sucsat3d(i,k)) ** (-1._kind_lake/bsw3d(i,k))
-      watopt3d(i,k) = watsat3d(i,k) * (158490._kind_lake/sucsat3d(i,k)) ** (-1._kind_lake/bsw3d(i,k))
-    end do
-    if (clm_lakedepth(i) == spval) then
-      clm_lakedepth(i) = zlak(nlevlake) + 0.5_kind_lake*dzlak(nlevlake)
-      z_lake3d(i,1:nlevlake) = zlak(1:nlevlake)
-      dz_lake3d(i,1:nlevlake) = dzlak(1:nlevlake)
-    else
-      depthratio2d(i) = clm_lakedepth(i) / (zlak(nlevlake) + 0.5_kind_lake*dzlak(nlevlake)) 
-      z_lake3d(i,1) = zlak(1)
-      dz_lake3d(i,1) = dzlak(1)
-      dz_lake3d(i,2:nlevlake) = dzlak(2:nlevlake)*depthratio2d(i)
-      z_lake3d(i,2:nlevlake) = zlak(2:nlevlake)*depthratio2d(i) + dz_lake3d(i,1)*(1._kind_lake - depthratio2d(i))
-    end if
     z3d(i,1:nlevsoil) = zsoi(1:nlevsoil)
     zi3d(i,0:nlevsoil) = zisoi(0:nlevsoil)
     dz3d(i,1:nlevsoil) = dzsoi(1:nlevsoil)
@@ -5633,9 +5586,9 @@ if_pergro: if (PERGRO) then
      if(lake_icefrac3d(i,1) > 0.) then
        depth = 0.
        do k=2,nlevlake
-         depth = depth + dz_lake3d(i,k)
+         depth = depth + dz_lake(k)
          if(hice(i) >= depth) then
-           lake_icefrac3d(i,k) = max(0.,lake_icefrac3d(i,1)+(0.-lake_icefrac3d(i,1))/z_lake3d(i,nlevlake)*depth)
+           lake_icefrac3d(i,k) = max(0.,lake_icefrac3d(i,1)+(0.-lake_icefrac3d(i,1))/z_lake(nlevlake)*depth)
          else
            lake_icefrac3d(i,k) = 0.
          endif
@@ -5649,8 +5602,8 @@ if_pergro: if (PERGRO) then
        t_grnd2d(i)          = max(tfrz,tsfc(i))
      endif
      do k = 2, nlevlake
-       if(z_lake3d(i,k).le.depth_c) then
-         t_lake3d(i,k) = tsfc(i)+(277.2_kind_lake-tsfc(i))/depth_c*z_lake3d(i,k)
+       if(z_lake(k).le.depth_c) then
+         t_lake3d(i,k) = tsfc(i)+(277.2_kind_lake-tsfc(i))/depth_c*z_lake(k)
        else
          t_lake3d(i,k) = 277.2_kind_lake
        end if
@@ -5684,7 +5637,8 @@ if_pergro: if (PERGRO) then
 
     do k = 1,nlevsoil
        h2osoi_vol3d(i,k) = 1.0_kind_lake
-       h2osoi_vol3d(i,k) = min(h2osoi_vol3d(i,k),watsat3d(i,k))
+       watsat = 0.489_kind_lake - 0.00126_kind_lake*sand(isl)
+       h2osoi_vol3d(i,k) = min(h2osoi_vol3d(i,k),watsat)
 
       ! soil layers
       if (t_soisno3d(i,k) <= tfrz) then

--- a/physics/clm_lake.meta
+++ b/physics/clm_lake.meta
@@ -289,6 +289,14 @@
   type = real
   kind = kind_phys
   intent = in
+[input_lakedepth]
+  standard_name = lake_depth_before_correction
+  long_name = lake depth_before_correction
+  units = m
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
 [wind]
   standard_name = wind_speed_at_lowest_model_layer
   long_name = wind speed at lowest model level
@@ -713,76 +721,6 @@
   long_name = snow interface_depth in clm lake model
   units = m
   dimensions = (horizontal_loop_extent,snow_plus_soil_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  intent = inout
-[z_lake3d]
-  standard_name = depth_of_lake_interface_layers
-  long_name = depth of lake interface layers
-  units = fraction
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  intent = inout
-[dz_lake3d]
-  standard_name = thickness_of_lake_layers
-  long_name = thickness of lake layers
-  units = fraction
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  intent = inout
-[watsat3d]
-  standard_name = saturated_volumetric_soil_water_in_lake_model
-  long_name = saturated volumetric soil water in lake model
-  units = m
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  intent = inout
-[csol3d]
-  standard_name = soil_heat_capacity_in_lake_model
-  long_name = soil heat capacity in lake model
-  units = m
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  intent = inout
-[sand3d]
-  standard_name = clm_lake_percent_sand
-  long_name = percent sand in clm lake model
-  units = percent
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_clm_lake_model)
-  type = integer
-  intent = inout
-[clay3d]
-  standard_name = clm_lake_percent_clay
-  long_name = percent clay in clm lake model
-  units = percent
-  dimensions = (horizontal_loop_extent,soil_vertical_dimension_for_clm_lake_model)
-  type = integer
-  intent = inout
-[tkmg3d]
-  standard_name = soil_mineral_thermal_conductivity_in_lake_model
-  long_name = soil mineral thermal conductivity in lake model
-  units = m
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  intent = inout
-[tkdry3d]
-  standard_name = dry_soil_thermal_conductivity_in_lake_model
-  long_name = dry soil thermal conductivity in lake model
-  units = m
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
-  type = real
-  kind = kind_phys
-  intent = inout
-[tksatu3d]
-  standard_name = saturated_soil_thermal_conductivity_in_lake_model
-  long_name = saturated soil thermal conductivity in lake model
-  units = m
-  dimensions = (horizontal_loop_extent, lake_vertical_dimension_for_clm_lake_model)
   type = real
   kind = kind_phys
   intent = inout

--- a/physics/cu_c3_deep.F90
+++ b/physics/cu_c3_deep.F90
@@ -2078,9 +2078,9 @@ contains
 
 !> - Call rain_evap_below_cloudbase() to calculate evaporation below cloud base
 
-      call rain_evap_below_cloudbase(itf,ktf,its,ite,                    &
-           kts,kte,ierr,kbcon,xmb,psur,xland,qo_cup,                     &
-           po_cup,qes_cup,pwavo,edto,pwevo,pre,outt,outq)      !,outbuoy)
+!      call rain_evap_below_cloudbase(itf,ktf,its,ite,                    &
+!           kts,kte,ierr,kbcon,xmb,psur,xland,qo_cup,                     &
+!           po_cup,qes_cup,pwavo,edto,pwevo,pre,outt,outq)      !,outbuoy)
 
       k=1
 !$acc kernels
@@ -2137,7 +2137,7 @@ contains
          do k = ktop(i), 1, -1
               rain =  pwo(i,k) + edto(i) * pwdo(i,k)
               rn(i) = rn(i) + rain * xmb(i) * .001 * dtime
-            !if(po(i,k).gt.400.)then
+              if(k.gt.jmin(i))then
               if(flg(i))then
               q1=qo(i,k)+(outq(i,k))*dtime
               t1=tn(i,k)+(outt(i,k))*dtime
@@ -2162,7 +2162,7 @@ contains
                 pre(i)=max(pre(i),0.)
                 delqev(i) = delqev(i) + .001*dp*qevap(i)/g
               endif
-            !endif ! 400mb
+            endif 
           endif
         enddo
 !       pre(i)=1000.*rn(i)/dtime
@@ -4429,7 +4429,7 @@ endif
 !
 !now do the rest
 !
-            kklev(i)=maxloc(zu(i,:),1)
+            kklev(i)=maxloc(zu(i,2:ktop(i)),1)
 !$acc loop seq
             do k=kbcon(i)+1,ktop(i)
                if(t(i,k) > 273.16) then
@@ -4489,6 +4489,10 @@ endif
                endif
                if(k.gt.kbcon(i)+1)c1d(i,k)=clwdet*up_massdetr(i,k-1)
                if(k.gt.kbcon(i)+1)c1d_b(i,k)=clwdet*up_massdetr(i,k-1)
+               !if(is_deep.and.k.gt.kklev(i))then
+                c1d(i,k)=0.005
+                c1d_b(i,k)=0.005
+               !endif
 
                if(autoconv.eq.2) then
 ! 

--- a/physics/cu_c3_deep.F90
+++ b/physics/cu_c3_deep.F90
@@ -2078,10 +2078,6 @@ contains
 
 !> - Call rain_evap_below_cloudbase() to calculate evaporation below cloud base
 
-!      call rain_evap_below_cloudbase(itf,ktf,its,ite,                    &
-!           kts,kte,ierr,kbcon,xmb,psur,xland,qo_cup,                     &
-!           po_cup,qes_cup,pwavo,edto,pwevo,pre,outt,outq)      !,outbuoy)
-
       k=1
 !$acc kernels
       do i=its,itf

--- a/physics/cu_c3_deep.F90
+++ b/physics/cu_c3_deep.F90
@@ -159,12 +159,12 @@ contains
         nranflag,itf,ktf,its,ite, kts,kte,ipr,imid
      integer, intent (in   )              ::                &
         ichoice
-     real(kind=kind_phys),  dimension (its:ite,4)                 &
+     real(kind=kind_phys),  dimension (its:,:)                 &
         ,intent (in  )                   ::  rand_clos
-     real(kind=kind_phys),  dimension (its:ite)                   &
+     real(kind=kind_phys),  dimension (its:)                   &
         ,intent (in  )                   ::  rand_mom,rand_vmas
 !$acc declare copyin(rand_clos,rand_mom,rand_vmas)
-     real(kind=kind_phys), intent(in), dimension (its:ite) :: ca_deep(:)
+     real(kind=kind_phys), intent(in), dimension (its:) :: ca_deep(:)
      integer, intent(in) :: do_capsuppress
      real(kind=kind_phys), intent(in), dimension(:) :: cap_suppress_j
 !$acc declare create(cap_suppress_j)
@@ -177,28 +177,28 @@ contains
   ! outq   = output q tendency (per s)
   ! outqc  = output qc tendency (per s)
   ! pre    = output precip
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (inout  )                   ::                         &
         cnvwt,outu,outv,outt,outq,outqc,cupclw
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (out    )                   ::                         &
         frh_out,rainevap
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (in  )                      ::                         &
         tmf, qmicro, sigmain, forceqv_spechum
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (inout  )                   ::                         &
         pre,xmb_out
 !$acc declare copy(cnvwt,outu,outv,outt,outq,outqc,cupclw,frh_out,pre,xmb_out)
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (in  )                   ::                            &
         hfx,qfx,xmbm_in,xmbs_in
 !$acc declare copyin(hfx,qfx,xmbm_in,xmbs_in)
-     integer,    dimension (its:ite)                                   &
+     integer,    dimension (its:)                                   &
         ,intent (inout  )                ::                            &
         kbcon,ktop
 !$acc declare copy(kbcon,ktop)
-     integer,    dimension (its:ite)                                   &
+     integer,    dimension (its:)                                   &
         ,intent (in  )                   ::                            &
         kpbl,tropics
 !$acc declare copyin(kpbl,tropics)
@@ -207,26 +207,26 @@ contains
   ! omega (omeg), windspeed (us,vs), and a flag (ierr) to turn off
   ! convection for this call only and at that particular gridpoint
   !
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (in   )                   ::                           &
         dhdt,rho,t,po,us,vs,tn,delp
 !$acc declare copyin(dhdt,rho,t,po,us,vs,tn)
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (inout   )                ::                           &
         omeg
 !$acc declare copy(omeg)
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (inout)                   ::                           &
          q,qo,zuo,zdo,zdm
 !$acc declare sigmaout                                                                                                                                                      
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (out)                     ::                           &
          sigmaout
-     real(kind=kind_phys), dimension (its:ite)                                         &
+     real(kind=kind_phys), dimension (its:)                                         &
         ,intent (in   )                   ::                           &
         dx,z1,psur,xland
 !$acc declare copyin(dx,z1,psur,xland)
-     real(kind=kind_phys), dimension (its:ite)                                         &
+     real(kind=kind_phys), dimension (its:)                                         &
         ,intent (inout   )                ::                           &
         mconv,ccn
 !$acc declare copy(mconv,ccn)
@@ -372,8 +372,8 @@ contains
 !$acc       kzdown,kdet,k22,jmin,kstabi,kstabm,k22x,xland1,              &
 !$acc       ktopdby,kbconx,ierr2,ierr3,kbmax)
 
-     integer,  dimension (its:ite), intent(inout) :: ierr
-     integer,  dimension (its:ite), intent(in) :: csum
+     integer,  dimension (its:), intent(inout) :: ierr
+     integer,  dimension (its:), intent(in) :: csum
      logical, intent(in) :: do_ca, progsigma
      logical, intent(in) :: flag_init, flag_restart
 !$acc declare copy(ierr) copyin(csum)
@@ -421,7 +421,7 @@ contains
 !$acc                tn_bl, qo_bl, qeso_bl, heo_bl, heso_bl,            &
 !$acc                qeso_cup_bl,qo_cup_bl, heo_cup_bl,heso_cup_bl,     &
 !$acc                gammao_cup_bl,tn_cup_bl,hco_bl,dbyo_bl,xf_dicycle)
-     real(kind=kind_phys), intent(inout), dimension(its:ite,10) :: forcing
+     real(kind=kind_phys), intent(inout), dimension(its:,:) :: forcing
 !$acc declare copy(forcing)
      integer :: turn,pmin_lev(its:ite),start_level(its:ite),ktopkeep(its:ite)
      real(kind=kind_phys),    dimension (its:ite,kts:kte) :: dtempdz
@@ -2418,16 +2418,16 @@ contains
 
 
    integer                           ,intent(in)    :: itf,ktf, its,ite, kts,kte
-   integer, dimension(its:ite)       ,intent(in)    :: ierr,kbcon
-   real(kind=kind_phys), dimension(its:ite)        ,intent(in)    ::psur,xland,pwavo,edto,pwevo,xmb
-   real(kind=kind_phys), dimension(its:ite,kts:kte),intent(in)    :: po_cup,qo_cup,qes_cup
-   real(kind=kind_phys), dimension(its:ite)        ,intent(inout) :: pre
-   real(kind=kind_phys), dimension(its:ite,kts:kte),intent(inout) :: outt,outq  !,outbuoy
+   integer, dimension(its:)       ,intent(in)    :: ierr,kbcon
+   real(kind=kind_phys), dimension(its:)        ,intent(in)    ::psur,xland,pwavo,edto,pwevo,xmb
+   real(kind=kind_phys), dimension(its:,kts:),intent(in)    :: po_cup,qo_cup,qes_cup
+   real(kind=kind_phys), dimension(its:)        ,intent(inout) :: pre
+   real(kind=kind_phys), dimension(its:,kts:),intent(inout) :: outt,outq  !,outbuoy
 !$acc declare copyin(ierr,kbcon,psur,xland,pwavo,edto,pwevo,xmb,po_cup,qo_cup,qes_cup)
 !$acc declare copy(pre,outt,outq)
 
-  !real,    dimension(its:ite)        ,intent(out)      :: tot_evap_bcb
-  !real,    dimension(its:ite,kts:kte),intent(out) :: evap_bcb,net_prec_bcb
+  !real,    dimension(its:)        ,intent(out)      :: tot_evap_bcb
+  !real,    dimension(its:,kts:),intent(out) :: evap_bcb,net_prec_bcb
 
   !-- locals
    integer :: i,k
@@ -2511,30 +2511,30 @@ contains
   !
   ! ierr error value, maybe modified in this routine
   !
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                    &
+     real(kind=kind_phys),    dimension (its:,kts:)                    &
         ,intent (in   )                   ::                 &
         rho,us,vs,z,p,pw
-     real(kind=kind_phys),    dimension (its:ite,1)                          &
+     real(kind=kind_phys),    dimension (its:,: )                          &
         ,intent (out  )                   ::                 &
         edtc
-     real(kind=kind_phys),    dimension (its:ite)                            &
+     real(kind=kind_phys),    dimension (its:)                            &
         ,intent (out )                    ::                 &
         pefc
-     real(kind=kind_phys),    dimension (its:ite)                            &
+     real(kind=kind_phys),    dimension (its:)                            &
         ,intent (out  )                   ::                 &
         edt
-     real(kind=kind_phys),    dimension (its:ite)                            &
+     real(kind=kind_phys),    dimension (its:)                            &
         ,intent (in   )                   ::                 &
         pwav,pwev,psum2,psumh,edtmax,edtmin
-     integer, dimension (its:ite)                            &
+     integer, dimension (its:)                            &
         ,intent (in   )                   ::                 &
         ktop,kbcon,xland1
      real(kind=kind_phys),    intent (in  ) ::               &                 !HCB
         ccnclean
-     real(kind=kind_phys),    dimension (its:ite)            &
+     real(kind=kind_phys),    dimension (its:)            &
         ,intent (inout )                   ::                &
         ccn
-     integer, dimension (its:ite)                            &
+     integer, dimension (its:)                            &
         ,intent (inout)                   ::                 &
         ierr
 !$acc declare copyin(rho,us,vs,z,p,pw,pwav,pwev,psum2,psumh,edtmax,edtmin,ktop,kbcon)
@@ -2671,7 +2671,7 @@ contains
   ! pwev = total normalized integrated evaoprate (i2)
   ! entr= entrainment rate 
   !
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)               &
+     real(kind=kind_phys),    dimension (its:,kts:)               &
         ,intent (in   )                   ::            &
         zd,hes_cup,hcd,qes_cup,q_cup,z_cup,             &
         dd_massentr,dd_massdetr,gamma_cup,q,he,p_cup
@@ -2679,18 +2679,18 @@ contains
      integer                                            &
         ,intent (in   )                   ::            &
         iloop
-     integer, dimension (its:ite)                       &
+     integer, dimension (its:)                       &
         ,intent (in   )                   ::            &
         jmin
 !$acc declare copyin(jmin)
-     integer, dimension (its:ite)                       &
+     integer, dimension (its:)                       &
         ,intent (inout)                   ::            &
         ierr
 !$acc declare copy(ierr)
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)&
+     real(kind=kind_phys),    dimension (its:,kts:)&
         ,intent (out  )                   ::            &
         qcd,qrcd,pwd
-     real(kind=kind_phys),    dimension (its:ite)&
+     real(kind=kind_phys),    dimension (its:)&
         ,intent (out  )                   ::            &
         pwev,bu
 !$acc declare copyout(qcd,qrcd,pwd,pwev,bu)
@@ -2812,23 +2812,23 @@ contains
         its,ite, kts,kte
   !
   !
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                &
+     real(kind=kind_phys),    dimension (its:,kts:)                &
         ,intent (in   )                   ::             &
         p,t,q
 !$acc declare copyin(p,t,q)
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                &
+     real(kind=kind_phys),    dimension (its:,kts:)                &
         ,intent (out  )                   ::             &
         hes,qes
 !$acc declare copyout(hes,qes)
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                &
+     real(kind=kind_phys),    dimension (its:,kts:)                &
         ,intent (inout)                   ::             &
         he,z
 !$acc declare copy(he,z)
-     real(kind=kind_phys),    dimension (its:ite)                        &
+     real(kind=kind_phys),    dimension (its:)                        &
         ,intent (in   )                   ::             &
         psur,z1
 !$acc declare copyin(psur,z1)
-     integer, dimension (its:ite)                        &
+     integer, dimension (its:)                        &
         ,intent (inout)                   ::             &
         ierr
 !$acc declare copy(ierr)
@@ -2966,19 +2966,19 @@ contains
         itf,ktf,                                                    &
         its,ite, kts,kte
   !
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                        &
+     real(kind=kind_phys),    dimension (its:,kts:)                        &
         ,intent (in   )                   ::                     &
         qes,q,he,hes,z,p,t
 !$acc declare copyin(qes,q,he,hes,z,p,t)
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                        &
+     real(kind=kind_phys),    dimension (its:,kts:)                        &
         ,intent (out  )                   ::                     &
         qes_cup,q_cup,he_cup,hes_cup,z_cup,p_cup,gamma_cup,t_cup
 !$acc declare copyout(qes_cup,q_cup,he_cup,hes_cup,z_cup,p_cup,gamma_cup,t_cup)
-     real(kind=kind_phys),    dimension (its:ite)                                &
+     real(kind=kind_phys),    dimension (its:)                                &
         ,intent (in   )                   ::                     &
         psur,z1
 !$acc declare copyin(psur,z1)
-     integer, dimension (its:ite)                                &
+     integer, dimension (its:)                                &
         ,intent (inout)                   ::                     &
         ierr
 !$acc declare copy(ierr)
@@ -3077,33 +3077,33 @@ contains
   ! k22         = updraft originating level
   ! ichoice       = flag if only want one closure (usually set to zero!)
   !
-     real(kind=kind_phys),    dimension (its:ite,1:maxens3)                            &
+     real(kind=kind_phys),    dimension (its:,1:)                            &
         ,intent (inout)                   ::                           &
         pr_ens
-     real(kind=kind_phys),    dimension (its:ite,1:maxens3)                            &
+     real(kind=kind_phys),    dimension (its:,1:)                            &
         ,intent (inout  )                 ::                           &
         xf_ens
 !$acc declare copy(pr_ens,xf_ens)
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (in   )                   ::                           &
         zd,zu,p_cup,zdm
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (in   )                   ::                           &
         omeg
-     real(kind=kind_phys),    dimension (its:ite,1)                                    &
+     real(kind=kind_phys),    dimension (its:,:)                                    &
         ,intent (in   )                   ::                           &
         xaa0
-     real(kind=kind_phys),    dimension (its:ite,4)                                    &
+     real(kind=kind_phys),    dimension (its:,:)                                    &
         ,intent (in   )                   ::                           &
        rand_clos 
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (in   )                   ::                           &
         aa1,edt,edtm,omegac,sigmab
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (in   )                   ::                           &
         mconv,axx
 !$acc declare copyin(zd,zu,p_cup,zdm,omeg,xaa0,rand_clos,aa1,edt,edtm,mconv,axx)
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (inout)                   ::                           &
         aa0,closure_n
 !$acc declare copy(aa0,closure_n)
@@ -3113,13 +3113,13 @@ contains
      real(kind=kind_phys)                                                              &
         ,intent (in   )                   ::                           &
         dtime
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (inout   )                ::                           &
         k22,kbcon,ktop
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (in      )                ::                           &
         xland
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (inout)                   ::                           &
         ierr,ierr2,ierr3
 !$acc declare copy(k22,kbcon,ktop,ierr,ierr2,ierr3) copyin(xland)
@@ -3129,10 +3129,10 @@ contains
       integer, intent(in)  :: dicycle
       logical, intent (in) :: progsigma
 
-      real(kind=kind_phys),    intent(in)   , dimension (its:ite) :: aa1_bl,tau_ecmwf
-      real(kind=kind_phys),    intent(inout), dimension (its:ite) :: xf_dicycle
-      real(kind=kind_phys),    intent(out),   dimension (its:ite) :: xf_progsigma
-      real(kind=kind_phys),    intent(inout), dimension (its:ite,10) :: forcing
+      real(kind=kind_phys),    intent(in)   , dimension (its:) :: aa1_bl,tau_ecmwf
+      real(kind=kind_phys),    intent(inout), dimension (its:) :: xf_dicycle
+      real(kind=kind_phys),    intent(out),   dimension (its:) :: xf_progsigma
+      real(kind=kind_phys),    intent(inout), dimension (its:,:) :: forcing
 !$acc declare copyin(aa1_bl,tau_ecmwf) copy(xf_dicycle,forcing)
       !- local var
       real(kind=kind_phys)  :: xff_dicycle
@@ -3487,31 +3487,31 @@ endif
   ! 
   ! ierr error value, maybe modified in this routine
   !
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (in   )                   ::                           &
         he_cup,hes_cup,p_cup
 !$acc declare copyin(he_cup,hes_cup,p_cup)
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (in   )                   ::                           &
         entr_rate,ztexec,zqexec,cap_inc,cap_max
 !$acc declare copyin(entr_rate,ztexec,zqexec,cap_inc,cap_max)
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (inout   )                   ::                        &
         hkb !,cap_max
 !$acc declare copy(hkb)
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (in   )                   ::                           &
         kbmax
 !$acc declare copyin(kbmax)
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (inout)                   ::                           &
         kbcon,k22,ierr
 !$acc declare copy(kbcon,k22,ierr)
      integer                                                           &
         ,intent (in   )                   ::                           &
         iloop_in
-     character*50 :: ierrc(its:ite)
-     real(kind=kind_phys), dimension (its:ite,kts:kte),intent (in) :: z_cup,heo
+     character*50 :: ierrc(its:)
+     real(kind=kind_phys), dimension (its:,kts:),intent (in) :: z_cup,heo
 !$acc declare copyin(z_cup,heo)
      integer, dimension (its:ite)      ::     iloop,start_level
 !$acc declare create(iloop,start_level)
@@ -3645,18 +3645,18 @@ endif
   ! x output array with return values
   ! kt output array of levels
   ! ks,kend  check-range
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (in   )                   ::                           &
          array
 !$acc declare copyin(array)
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (in   )                   ::                           &
          ierr,ke
 !$acc declare copyin(ierr,ke)
      integer                                                           &
         ,intent (in   )                   ::                           &
          ks
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (out  )                   ::                           &
          maxx
 !$acc declare copyout(maxx)
@@ -3708,15 +3708,15 @@ endif
   ! x output array with return values
   ! kt output array of levels
   ! ks,kend  check-range
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                    &
+     real(kind=kind_phys),    dimension (its:,kts:)                    &
         ,intent (in   )                   ::                 &
          array
 !$acc declare copyin(array)
-     integer, dimension (its:ite)                            &
+     integer, dimension (its:)                            &
         ,intent (in   )                   ::                 &
          ierr,ks,kend
 !$acc declare copyin(ierr,ks,kend)
-     integer, dimension (its:ite)                            &
+     integer, dimension (its:)                            &
         ,intent (out  )                   ::                 &
          kt
 !$acc declare copyout(kt)
@@ -3771,10 +3771,10 @@ endif
   ! z = heights of model levels 
   ! ierr error value, maybe modified in this routine
   !
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                     &
+     real(kind=kind_phys),    dimension (its:,kts:)                     &
         ,intent (in   )                   ::                  &
         z,zu,gamma_cup,t_cup,dby
-     integer, dimension (its:ite)                             &
+     integer, dimension (its:)                             &
         ,intent (in   )                   ::                  &
         kbcon,ktop
 !$acc declare copyin(z,zu,gamma_cup,t_cup,dby,kbcon,ktop)
@@ -3783,11 +3783,11 @@ endif
 !
 
 
-     integer, dimension (its:ite)                             &
+     integer, dimension (its:)                             &
         ,intent (inout)                   ::                  &
         ierr
 !$acc declare copy(ierr)
-     real(kind=kind_phys),    dimension (its:ite)                             &
+     real(kind=kind_phys),    dimension (its:)                             &
         ,intent (out  )                   ::                  &
         aa0
 !$acc declare copyout(aa0)
@@ -3830,15 +3830,15 @@ endif
                         outqc,pret,its,ite,kts,kte,itf,ktf,ktop)
 
    integer,      intent(in   ) ::            j,its,ite,kts,kte,itf,ktf
-   integer, dimension (its:ite  ),   intent(in   ) ::  ktop
+   integer, dimension (its:  ),   intent(in   ) ::  ktop
 
-     real(kind=kind_phys), dimension (its:ite,kts:kte  )                    ,                 &
+     real(kind=kind_phys), dimension (its:,kts:  )                    ,                 &
       intent(inout   ) ::                                                     &
        outq,outt,outqc,outu,outv
-     real(kind=kind_phys), dimension (its:ite,kts:kte  )                    ,                 &
+     real(kind=kind_phys), dimension (its:,kts:  )                    ,                 &
       intent(inout   ) ::                                                     &
        q
-     real(kind=kind_phys), dimension (its:ite  )                            ,                 &
+     real(kind=kind_phys), dimension (its:  )                            ,                 &
       intent(inout   ) ::                                                     &
        pret
 !$acc declare copy(outq,outt,outqc,outu,outv,q,pret)
@@ -3979,38 +3979,38 @@ endif
   ! pw = pw -epsilon*pd (ensemble dependent)
   ! ierr error value, maybe modified in this routine
   !
-     real(kind=kind_phys),    dimension (its:ite,1:maxens3)                            &
+     real(kind=kind_phys),    dimension (its:,:)                            &
         ,intent (inout)                   ::                           &
        xf_ens,pr_ens
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (inout  )                 ::                           &
         outtem,outq,outqc
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (in  )                    ::                           &
         zu,pwd,p_cup
-     real(kind=kind_phys),   dimension (its:ite)                                       &
+     real(kind=kind_phys),   dimension (its:)                                       &
          ,intent (in  )                   ::                           &
         sig,xmbm_in,xmbs_in,edt,sigmab,dx
-     real(kind=kind_phys),   dimension (its:ite,2)                                     &
+     real(kind=kind_phys),   dimension (its:,:)                                     &
          ,intent (in  )                   ::                           &
         xff_mid
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (inout  )                 ::                           &
         pre,xmb
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (inout  )                 ::                           &
         closure_n
-     real(kind=kind_phys),    dimension (its:ite,kts:kte,1)                            &
+     real(kind=kind_phys),    dimension (its:,kts:,:)                            &
         ,intent (in   )                   ::                           &
        dellat,dellaqc,dellaq,pw
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (in   )                   ::                           &
         ktop,xland1
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (inout)                   ::                           &
         ierr,ierr2,ierr3
      integer, intent(in) :: dicycle
-     real(kind=kind_phys),    intent(in), dimension (its:ite) :: xf_dicycle, xf_progsigma
+     real(kind=kind_phys),    intent(in), dimension (its:) :: xf_dicycle, xf_progsigma
 !$acc declare copyin(zu,pwd,p_cup,sig,xmbm_in,xmbs_in,edt,xff_mid,dellat,dellaqc,dellaq,pw,ktop,xland1,xf_dicycle)
 !$acc declare copy(xf_ens,pr_ens,outtem,outq,outqc,pre,xmb,closure_n,ierr,ierr2,ierr3)
 !
@@ -4248,15 +4248,15 @@ endif
   ! zu = normalized updraft mass flux
   ! gamma_cup = gamma on model cloud levels
   !
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                         &
+     real(kind=kind_phys),    dimension (its:,kts:)                         &
         ,intent (in   )                   ::                      &
         p_cup,rho,q,zu,gamma_cup,qe_cup,                          &
         up_massentr,up_massdetr,dby,qes_cup,z_cup
-     real(kind=kind_phys),    dimension (its:ite)                                 &
+     real(kind=kind_phys),    dimension (its:)                                 &
         ,intent (in   )                   ::                      &
         zqexec,c0
   ! entr= entrainment rate 
-     integer, dimension (its:ite)                                 &
+     integer, dimension (its:)                                 &
         ,intent (in   )                   ::                      &
         kbcon,ktop,k22,xland1
 !$acc declare copyin(p_cup,rho,q,zu,gamma_cup,qe_cup,up_massentr,up_massdetr,dby,qes_cup,z_cup,zqexec,c0,kbcon,ktop,k22,xland1)
@@ -4268,7 +4268,7 @@ endif
 
    ! ierr error value, maybe modified in this routine
 
-     integer, dimension (its:ite)                                  &
+     integer, dimension (its:)                                  &
         ,intent (inout)                   ::                       &
         ierr
 !$acc declare copy(ierr)
@@ -4281,11 +4281,11 @@ endif
    ! pwav = totan normalized integrated condensate (i1)
    ! c0 = conversion rate (cloud to rain)
 
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                          &
+     real(kind=kind_phys),    dimension (its:,kts:)                          &
         ,intent (out  )                   ::                       &
         qc,qrc,pw,clw_all
 !$acc declare copy(qc,qrc,pw,clw_all)
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                          &
+     real(kind=kind_phys),    dimension (its:,kts:)                          &
         ,intent (inout)                   ::                       &
         c1d
 !$acc declare copy(c1d)
@@ -4295,11 +4295,11 @@ endif
      real(kind=kind_phys),    dimension (its:ite)         ::                       &
         pwavh
 !$acc declare create(pwavh)
-     real(kind=kind_phys),    dimension (its:ite)                                  &
+     real(kind=kind_phys),    dimension (its:)                                  &
         ,intent (out  )                   ::                       &
         pwav,psum,psumh
 !$acc declare copyout(pwav,psum,psumh)
-     real(kind=kind_phys),    dimension (its:ite)                                  &
+     real(kind=kind_phys),    dimension (its:)                                  &
         ,intent (in  )                    ::                       &
         ccn
 !$acc declare copyin(ccn)
@@ -4329,7 +4329,7 @@ endif
         is_deep = (name == 'deep')
 
 !$acc kernels
-        prop_b(kts:kte)=0
+        prop_b(kts:)=0
 !$acc end kernels
         iall=0
         clwdet=0.1 !0.02
@@ -4646,11 +4646,11 @@ endif
      implicit none
      character *(*), intent (in)       :: name
      integer, intent(in) :: ipr,its,ite,itf,kts,kte,ktf
-     real(kind=kind_phys), dimension (its:ite,kts:kte),intent (inout) :: entr_rate_2d,zuo
-     real(kind=kind_phys), dimension (its:ite,kts:kte),intent (in) ::p_cup, heo,heso_cup,z_cup
-     real(kind=kind_phys), dimension (its:ite),intent (in) :: hkbo,rand_vmas
-     integer, dimension (its:ite),intent (in) :: kstabi,k22,kpbl,csum,xland,pmin_lev
-     integer, dimension (its:ite),intent (inout) :: kbcon,ierr,ktop,ktopdby
+     real(kind=kind_phys), dimension (its:,kts:),intent (inout) :: entr_rate_2d,zuo
+     real(kind=kind_phys), dimension (its:,kts:),intent (in) ::p_cup, heo,heso_cup,z_cup
+     real(kind=kind_phys), dimension (its:),intent (in) :: hkbo,rand_vmas
+     integer, dimension (its:),intent (in) :: kstabi,k22,kpbl,csum,xland,pmin_lev
+     integer, dimension (its:),intent (inout) :: kbcon,ierr,ktop,ktopdby
 !$acc declare copy(entr_rate_2d,zuo,kbcon,ierr,ktop,ktopdby) &
 !$acc         copyin(p_cup, heo,heso_cup,z_cup,hkbo,rand_vmas,kstabi,k22,kpbl,csum,xland,pmin_lev)
 
@@ -4737,7 +4737,7 @@ endif
               ktop(i)= 0
         else
            call get_zu_zd_pdf_fim(kklev,p_cup(i,:),rand_vmas(i),zubeg,ipr,xland(i),zuh2,1,ierr(i),k22(i), &
-            kfinalzu+1,zuo(i,kts:kte),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
+            kfinalzu+1,zuo(i,kts:),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
         endif
       endif ! end deep
       if ( is_mid ) then
@@ -4748,7 +4748,7 @@ endif
            kfinalzu=ktop(i)
            ktopdby(i)=ktop(i)+1
           call get_zu_zd_pdf_fim(kklev,p_cup(i,:),rand_vmas(i),zubeg,ipr,xland(i),zuh2,3, &
-            ierr(i),k22(i),ktopdby(i)+1,zuo(i,kts:kte),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
+            ierr(i),k22(i),ktopdby(i)+1,zuo(i,kts:),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
        endif
       endif ! mid
       if ( is_shallow ) then
@@ -4759,7 +4759,7 @@ endif
            kfinalzu=ktop(i)
            ktopdby(i)=ktop(i)+1
            call get_zu_zd_pdf_fim(kbcon(i),p_cup(i,:),rand_vmas(i),zubeg,ipr,xland(i),zuh2,2,ierr(i),k22(i), &
-             ktopdby(i)+1,zuo(i,kts:kte),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
+             ktopdby(i)+1,zuo(i,kts:),kts,kte,ktf,beta_u,kbcon(i),csum(i),pmin_lev(i))
 
          endif
          endif ! shal
@@ -4782,8 +4782,8 @@ endif
  real(kind=kind_phys), parameter :: beta_dd=4.0,g_beta_dd=6.
  integer, intent(in) ::ipr,xland,kb,kklev,kt,kts,kte,ktf,kpbli,csum,pmin_lev
  real(kind=kind_phys), intent(in) ::max_mass,zubeg
- real(kind=kind_phys), intent(inout) :: zu(kts:kte)
- real(kind=kind_phys), intent(in) :: p(kts:kte)
+ real(kind=kind_phys), intent(inout) :: zu(kts:)
+ real(kind=kind_phys), intent(in) :: p(kts:)
  real(kind=kind_phys)  :: trash,beta_deep,zuh(kts:kte),zuh2(1:40)
  integer, intent(inout) :: ierr
  integer, intent(in) ::draft
@@ -5057,20 +5057,20 @@ endif
   ! z = heights of model levels 
   ! ierr error value, maybe modified in this routine
   !
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (in   )                   ::                           &
         z_cup,zu,gamma_cup,t_cup,dby,t,tn,q,qo
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (in   )                   ::                           &
         kbcon,ktop
      real(kind=kind_phys), intent(in) :: dtime
 !
 ! input and output
 !
-     integer, dimension (its:ite)                                      &
+     integer, dimension (its:)                                      &
         ,intent (inout)                   ::                           &
         ierr
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (out  )                   ::                           &
         aa0
 !
@@ -5107,14 +5107,14 @@ endif
                                     
         implicit none
         integer                      ,intent (in ) :: itf,ktf,its,ite,kts,kte
-        integer, dimension (its:ite) ,intent (in ) :: ierr,kstart,kend
+        integer, dimension (its:) ,intent (in ) :: ierr,kstart,kend
 !$acc declare copyin(ierr,kstart,kend)
         integer, dimension (its:ite) :: kend_p3
 !$acc declare create(kend_p3)
                     
-        real(kind=kind_phys),    dimension (its:ite,kts:kte), intent (in ) :: p_cup,t_cup,z_cup,qo_cup,qeso_cup                            
-        real(kind=kind_phys),    dimension (its:ite,kts:kte), intent (out) :: dtempdz                    
-        integer, dimension (its:ite,kts:kte), intent (out) :: k_inv_layers
+        real(kind=kind_phys),    dimension (its:,kts:), intent (in ) :: p_cup,t_cup,z_cup,qo_cup,qeso_cup                            
+        real(kind=kind_phys),    dimension (its:,kts:), intent (out) :: dtempdz                    
+        integer, dimension (its:,kts:), intent (out) :: k_inv_layers
 !$acc declare copyin(p_cup,t_cup,z_cup,qo_cup,qeso_cup)
 !$acc declare copyout(dtempdz,k_inv_layers)
         !-local vars
@@ -5308,15 +5308,15 @@ endif
      implicit none
      integer, intent (in) :: draft
      integer, intent(in):: itf,ktf, its,ite, kts,kte
-     integer, intent(in)   , dimension(its:ite)         :: ierr,ktop,kbcon,k22
+     integer, intent(in)   , dimension(its:)         :: ierr,ktop,kbcon,k22
 !$acc declare copyin(ierr,ktop,kbcon,k22)
-    !real(kind=kind_phys),    intent(in),  optional , dimension(its:ite):: lambau
-     real(kind=kind_phys),    intent(inout),  optional , dimension(its:ite):: lambau
-     real(kind=kind_phys),    intent(in)   , dimension(its:ite,kts:kte) :: zo_cup,zuo
-     real(kind=kind_phys),    intent(inout), dimension(its:ite,kts:kte) :: cd,entr_rate_2d   
-     real(kind=kind_phys),    intent(  out), dimension(its:ite,kts:kte) :: up_massentro, up_massdetro  &
+    !real(kind=kind_phys),    intent(in),  optional , dimension(its:):: lambau
+     real(kind=kind_phys),    intent(inout),  optional , dimension(its:):: lambau
+     real(kind=kind_phys),    intent(in)   , dimension(its:,kts:) :: zo_cup,zuo
+     real(kind=kind_phys),    intent(inout), dimension(its:,kts:) :: cd,entr_rate_2d   
+     real(kind=kind_phys),    intent(  out), dimension(its:,kts:) :: up_massentro, up_massdetro  &
                                                           ,up_massentr,  up_massdetr
-     real(kind=kind_phys),    intent(  out), dimension(its:ite,kts:kte),  optional ::                  &
+     real(kind=kind_phys),    intent(  out), dimension(its:,kts:),  optional ::                  &
                                                           up_massentru,up_massdetru
 !$acc declare copy(lambau,cd,entr_rate_2d) copyin(zo_cup,zuo) copyout(up_massentro, up_massdetro,up_massentr,  up_massdetr)
 !$acc declare copyout(up_massentro, up_massdetro,up_massentr,  up_massdetr, up_massentru,up_massdetru)
@@ -5437,10 +5437,10 @@ endif
      implicit none
      character *(*), intent (in)                          :: cumulus
      integer  ,intent (in   )	                          :: itf,ktf, its,ite, kts,kte
-     real(kind=kind_phys),     intent (in   ), dimension(its:ite,kts:kte) :: tn,po_cup
-     real(kind=kind_phys),     intent (inout), dimension(its:ite,kts:kte) :: p_liq_ice,melting_layer
+     real(kind=kind_phys),     intent (in   ), dimension(its:,kts:) :: tn,po_cup
+     real(kind=kind_phys),     intent (inout), dimension(its:,kts:) :: p_liq_ice,melting_layer
 !$acc declare copyin(tn,po_cup) copy(p_liq_ice,melting_layer)
-     integer  , intent (in  ), dimension(its:ite) :: ierr
+     integer  , intent (in  ), dimension(its:) :: ierr
 !$acc declare copyin(ierr)
      integer :: i,k
      real(kind=kind_phys)    :: dp     
@@ -5539,11 +5539,11 @@ endif
      implicit none
      character *(*), intent (in)                          :: cumulus
      integer  ,intent (in   )                                  :: itf,ktf, its,ite, kts,kte
-     integer  ,intent (in   ), dimension(its:ite)         :: ierr
-     real(kind=kind_phys)     ,intent (in   ), dimension(its:ite)         :: edto
-     real(kind=kind_phys)     ,intent (in   ), dimension(its:ite,kts:kte) :: tn_cup,po_cup,qrco,pwo &
+     integer  ,intent (in   ), dimension(its:)         :: ierr
+     real(kind=kind_phys)     ,intent (in   ), dimension(its:)         :: edto
+     real(kind=kind_phys)     ,intent (in   ), dimension(its:,kts:) :: tn_cup,po_cup,qrco,pwo &
                                                             ,pwdo,p_liq_ice,melting_layer
-     real(kind=kind_phys)     ,intent (inout), dimension(its:ite,kts:kte) :: melting
+     real(kind=kind_phys)     ,intent (inout), dimension(its:,kts:) :: melting
 !$acc declare copyin(ierr,edto,tn_cup,po_cup,qrco,pwo,pwdo,p_liq_ice,melting_layer,melting)
      integer :: i,k
      real(kind=kind_phys)    :: dp     
@@ -5615,13 +5615,13 @@ endif
                          kstabi,k22,kbcon,its,ite,itf,kts,kte,ktf,zuo,kpbl,klcl,hcot)
      implicit none
      integer, intent(in) :: its,ite,itf,kts,kte,ktf
-     real(kind=kind_phys), dimension (its:ite,kts:kte),intent (inout) :: entr_rate_2d,zuo
-     real(kind=kind_phys), dimension (its:ite,kts:kte),intent (in) ::p_cup, heo,heso_cup,z_cup
-     real(kind=kind_phys), dimension (its:ite),intent (in) :: hkbo
-     integer, dimension (its:ite),intent (in) :: kstabi,k22,kbcon,kpbl,klcl
-     integer, dimension (its:ite),intent (inout) :: ierr,ktop
+     real(kind=kind_phys), dimension (its:,kts:),intent (inout) :: entr_rate_2d,zuo
+     real(kind=kind_phys), dimension (its:,kts:),intent (in) ::p_cup, heo,heso_cup,z_cup
+     real(kind=kind_phys), dimension (its:),intent (in) :: hkbo
+     integer, dimension (its:),intent (in) :: kstabi,k22,kbcon,kpbl,klcl
+     integer, dimension (its:),intent (inout) :: ierr,ktop
 !$acc declare copy(entr_rate_2d,zuo,ierr,ktop) copyin(p_cup, heo,heso_cup,z_cup,hkbo,kstabi,k22,kbcon,kpbl,klcl)
-     real(kind=kind_phys), dimension (its:ite,kts:kte) :: hcot
+     real(kind=kind_phys), dimension (its:,kts:) :: hcot
 !$acc declare create(hcot)
      character *(*), intent (in) ::    name
      real(kind=kind_phys) :: dz,dh, dbythresh
@@ -5644,7 +5644,7 @@ endif
        kfinalzu=ktf-2
        ktop(i)=kfinalzu
        if(ierr(i).eq.0)then
-       dby (kts:kte)=0.0
+       dby (kts:)=0.0
 
        start_level(i)=kbcon(i)
        !-- hcot below kbcon
@@ -5704,16 +5704,16 @@ endif
     implicit none
     logical, intent(in) :: progsigma
     integer, intent(in) :: itf,its,ktf,ite,kts,kte
-    integer, dimension (its:ite), intent(inout) :: ierr
-    real(kind=kind_phys), dimension (its:ite,kts:kte),intent (in) :: zo,entr_rate_2d,   &
+    integer, dimension (its:), intent(inout) :: ierr
+    real(kind=kind_phys), dimension (its:,kts:),intent (in) :: zo,entr_rate_2d,   &
          cd,po,qeso,to,qo,dbyo,clw_all,qlk,delp,zu
-    integer, dimension (its:ite),intent(in) :: k22,kbcon,ktcon
+    integer, dimension (its:),intent(in) :: k22,kbcon,ktcon
     real(kind=kind_phys), dimension (its:ite) :: sumx
     real(kind=kind_phys) ,intent (in) :: fv,rd,el2orc 
     real(kind=kind_phys), dimension (its:ite,kts:kte) :: drag, buo, zi, del
-    real(kind=kind_phys), dimension (its:ite,kts:kte),intent (out) :: wu2,omega_u,      &
+    real(kind=kind_phys), dimension (its:,kts:),intent (out) :: wu2,omega_u,      &
          zeta,zdqca
-    real(kind=kind_phys), dimension (its:ite),intent(out) :: wc,omegac
+    real(kind=kind_phys), dimension (its:),intent(out) :: wc,omegac
     real(kind=kind_phys) :: rho,bb1,bb2,dz,dp,ptem,tem1,ptem1,tem,rfact,gamma,val
     integer :: i,k    
 

--- a/physics/cu_c3_deep.F90
+++ b/physics/cu_c3_deep.F90
@@ -4489,10 +4489,8 @@ endif
                endif
                if(k.gt.kbcon(i)+1)c1d(i,k)=clwdet*up_massdetr(i,k-1)
                if(k.gt.kbcon(i)+1)c1d_b(i,k)=clwdet*up_massdetr(i,k-1)
-               !if(is_deep.and.k.gt.kklev(i))then
                 c1d(i,k)=0.005
                 c1d_b(i,k)=0.005
-               !endif
 
                if(autoconv.eq.2) then
 ! 

--- a/physics/cu_c3_driver.F90
+++ b/physics/cu_c3_driver.F90
@@ -949,38 +949,6 @@ contains
               !gdc(i,k,8)=(outq(i,k))*86400.*xlv/cp
                gdc(i,k,8)=(outqm(i,k)+outqs(i,k)+outq(i,k))*86400.*xlv/cp
                gdc(i,k,9)=gdc(i,k,2)+gdc(i,k,3)+gdc(i,k,4)
-!
-!> - Calculate subsidence effect on clw
-!
-!              dsubclw=0.
-!              dsubclwm=0.
-!              dsubclws=0.
-!              dp=100.*(p2d(i,k)-p2d(i,k+1))
-!              if (clcw(i,k) .gt. -999.0 .and. clcw(i,k+1) .gt. -999.0 )then
-!                 clwtot = cliw(i,k) + clcw(i,k)
-!                 clwtot1= cliw(i,k+1) + clcw(i,k+1)
-!                 dsubclw=((-edt(i)*zd(i,k+1)+zu(i,k+1))*clwtot1   &
-!                      -(-edt(i)*zd(i,k)  +zu(i,k))  *clwtot  )*g/dp
-!                 dsubclwm=((-edtm(i)*zdm(i,k+1)+zum(i,k+1))*clwtot1   &
-!                      -(-edtm(i)*zdm(i,k)  +zum(i,k))  *clwtot  )*g/dp
-!                 dsubclws=(zus(i,k+1)*clwtot1-zus(i,k)*clwtot)*g/dp
-!                 dsubclw=dsubclw+(zu(i,k+1)*clwtot1-zu(i,k)*clwtot)*g/dp
-!                 dsubclwm=dsubclwm+(zum(i,k+1)*clwtot1-zum(i,k)*clwtot)*g/dp
-!                 dsubclws=dsubclws+(zus(i,k+1)*clwtot1-zus(i,k)*clwtot)*g/dp
-!              endif
-!              tem  = dt*(outqcs(i,k)*cutens(i)+outqc(i,k)*cuten(i)       &
-!                    +outqcm(i,k)*cutenm(i)                           &
-!                     +dsubclw*xmb(i)+dsubclws*xmbs(i)+dsubclwm*xmbm(i) &
-!                    )
-!              tem1 = max(0.0, min(1.0, (tcr-t(i,k))*tcrf))
-!              if (clcw(i,k) .gt. -999.0) then
-!               cliw(i,k) = max(0.,cliw(i,k) + tem * tem1)            ! ice
-!               clcw(i,k) = max(0.,clcw(i,k) + tem *(1.0-tem1))       ! water
-!              else
-!                cliw(i,k) = max(0.,cliw(i,k) + tem)
-!              endif
-!
-!            enddo
 
 !> - FCT treats subsidence effect to cloud ice/water (begin)
                dp=100.*(p2d(i,k)-p2d(i,k+1))

--- a/physics/cu_c3_driver.F90
+++ b/physics/cu_c3_driver.F90
@@ -340,8 +340,8 @@ contains
 !
 !> - Set tuning constants for radiation coupling
 !
-     tun_rad_shall(:)=.01
-     tun_rad_mid(:)=.3 !.02
+     tun_rad_shall(:)=.012
+     tun_rad_mid(:)=.15 !.02
      tun_rad_deep(:)=.3 !.065
      edt(:)=0.
      edtm(:)=0.

--- a/physics/cu_c3_driver.F90
+++ b/physics/cu_c3_driver.F90
@@ -644,7 +644,6 @@ contains
      enddo
 !$acc end kernels
      if (dx(its)<6500.) then
-       ichoice=10
        imid_gf=0
      endif
 !
@@ -680,10 +679,6 @@ contains
           do i=its,itf
            if(xmbs(i).gt.0.)then
             cutens(i)=1.
-            if (dx(i)<6500.) then
-             ierrm(i)=555
-             ierr (i)=555
-            endif
            endif
           enddo
 !$acc end kernels
@@ -1041,8 +1036,8 @@ contains
             gdc(i,16,10)=pret(i)*3600.
 
             maxupmf(i)=0.
-            if(forcing(i,6).gt.0.)then
-              maxupmf(i)=maxval(xmb(i)*zu(i,kts:ktf)/forcing(i,6))
+            if(forcing2(i,6).gt.0.)then
+              maxupmf(i)=maxval(xmb(i)*zu(i,kts:ktf)/forcing2(i,6))
             endif
 
             if(ktop(i).gt.2 .and.pret(i).gt.0.)dt_mf(i,ktop(i)-1)=ud_mf(i,ktop(i))

--- a/physics/cu_c3_driver_post.F90
+++ b/physics/cu_c3_driver_post.F90
@@ -66,19 +66,18 @@ module cu_c3_driver_post
           conv_act_m(i)=0.0
         endif
         ! reflectivity parameterization for parameterized convection (reference:Unipost MDLFLD.f)
-        if(sqrt(garea(i)).lt.6500.)then
         ze      = 0.0
         ze_conv = 0.0
         dbz_sum = 0.0
-        cuprate = raincv(i) * 3600.0 / dt          ! cu precip rate (mm/h)
-        ze_conv = 300.0 * cuprate**1.4
-        if (maxupmf(i).gt.0.05) then
+        cuprate = max(0.1,1.e3*raincv(i) * 3600.0 / dt)          ! cu precip rate (mm/h)
+        if(cuprate .lt. 0.05) cuprate=0.
+        ze_conv = 300.0 * cuprate**1.5
+        if (maxupmf(i).gt.0.1 .and. cuprate.gt.0.) then
          do k = 1, km
           ze = 10._kind_phys ** (0.1 * refl_10cm(i,k))
           dbz_sum = max(dbzmin, 10.0 * log10(ze + ze_conv))
           refl_10cm(i,k) = dbz_sum
          enddo
-        endif
         endif
       enddo
 !$acc end kernels

--- a/physics/cu_c3_driver_post.F90
+++ b/physics/cu_c3_driver_post.F90
@@ -69,7 +69,7 @@ module cu_c3_driver_post
         ze      = 0.0
         ze_conv = 0.0
         dbz_sum = 0.0
-        cuprate = max(0.1,1.e3*raincv(i) * 3600.0 / dt)          ! cu precip rate (mm/h)
+        cuprate = 1.e3*raincv(i) * 3600.0 / dt          ! cu precip rate (mm/h)
         if(cuprate .lt. 0.05) cuprate=0.
         ze_conv = 300.0 * cuprate**1.5
         if (maxupmf(i).gt.0.1 .and. cuprate.gt.0.) then

--- a/physics/cu_c3_sh.F90
+++ b/physics/cu_c3_sh.F90
@@ -6,12 +6,12 @@ module cu_c3_sh
     use progsigma, only : progsigma_calc
 
     !real(kind=kind_phys), parameter:: c1_shal=0.0015! .0005
-    real(kind=kind_phys), parameter:: c1_shal=0. !0.005! .0005
     real(kind=kind_phys), parameter:: g  =9.81
     real(kind=kind_phys), parameter:: cp =1004.
     real(kind=kind_phys), parameter:: xlv=2.5e6
     real(kind=kind_phys), parameter:: r_v=461.
-    real(kind=kind_phys), parameter:: c0_shal=.001
+    real(kind=kind_phys)  :: c0_shal=.004
+    real(kind=kind_phys)  :: c1_shal=0. !0.005! .0005
     real(kind=kind_phys), parameter:: fluxtune=1.5
 
 contains
@@ -274,6 +274,8 @@ contains
         ktopx(i)=0
         if(xland(i).gt.1.5 .or. xland(i).lt.0.5)then
             xland1(i)=0
+            c0_shal=.001
+            c1_shal=.001
 !            ierr(i)=100
         endif
         pre(i)=0.
@@ -669,11 +671,11 @@ contains
           if(qco(i,k)>=trash ) then 
               dz=z_cup(i,k)-z_cup(i,k-1)
               ! cloud liquid water
-              c1d(i,k)=.02*up_massdetr(i,k-1)
+              c1d(i,k)=c1_shal! 0. !.02*up_massdetr(i,k-1)
               qrco(i,k)= (qco(i,k)-trash)/(1.+(c0_shal+c1d(i,k))*dz)
               if(qrco(i,k).lt.0.)then  ! hli new test 02/12/19
                  qrco(i,k)=0.
-                 c1d(i,k)=0.
+                 !c1d(i,k)=0.
               endif
               pwo(i,k)=c0_shal*dz*qrco(i,k)*zuo(i,k)
               clw_all(i,k)=qco(i,k)-trash !LB total cloud before rain and detrain

--- a/physics/cu_c3_sh.F90
+++ b/physics/cu_c3_sh.F90
@@ -95,23 +95,23 @@ contains
   ! outq   = output q tendency (per s)
   ! outqc  = output qc tendency (per s)
   ! pre    = output precip
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (inout  )                 ::                           &
         cnvwt,outt,outq,outqc,cupclw,zuo,outu,outv
 !$acc declare copy(cnvwt,outt,outq,outqc,cupclw,zuo,outu,outv)
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (in  )                      ::                         &
         tmf, qmicro, sigmain, forceqv_spechum
-     real(kind=kind_phys),    dimension (its:ite)                                      &
+     real(kind=kind_phys),    dimension (its:)                                      &
         ,intent (out  )                   ::                           &
         xmb_out
-     integer,    dimension (its:ite)                                   &
+     integer,    dimension (its:)                                   &
         ,intent (inout  )                 ::                           &
         ierr
-     integer,    dimension (its:ite)                                   &
+     integer,    dimension (its:)                                   &
         ,intent (out  )                   ::                           &
         kbcon,ktop,k22
-     integer,    dimension (its:ite)                                   &
+     integer,    dimension (its:)                                   &
         ,intent (in  )                    ::                           &
         kpbl,tropics
 !$acc declare copyout(xmb_out,kbcon,ktop,k22) copyin(kpbl,tropics) copy(ierr)
@@ -119,13 +119,13 @@ contains
   ! basic environmental input includes a flag (ierr) to turn off
   ! convection for this call only and at that particular gridpoint
   !
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (in   )                   ::                           &
         t,po,tn,dhdt,rho,us,vs,delp
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (inout)                   ::                           &
          q,qo
-     real(kind=kind_phys), dimension (its:ite)                                         &
+     real(kind=kind_phys), dimension (its:)                                         &
         ,intent (in   )                   ::                           &
         xland,z1,psur,hfx,qfx,dx
        
@@ -133,7 +133,7 @@ contains
         ,intent (in   )                   ::                           &
         dtime,tcrit,fv,r_d
 !$acc declare sigmaout                                                                                                                                                                                                                      
-     real(kind=kind_phys),    dimension (its:ite,kts:kte)                              &
+     real(kind=kind_phys),    dimension (its:,kts:)                              &
         ,intent (out)                     ::                           &
         sigmaout
 
@@ -245,7 +245,7 @@ contains
       real(kind=kind_phys) buo_flux,pgeoh,dp,entup,detup,totmas
 
      real(kind=kind_phys) xff_shal(3),blqe,xkshal
-     character*50 :: ierrc(its:ite)
+     character*50 :: ierrc(its:)
      real(kind=kind_phys),    dimension (its:ite,kts:kte) ::                           &
        up_massentr,up_massdetr,up_massentro,up_massdetro,up_massentru,up_massdetru
 !$acc declare create(up_massentr,up_massdetr,up_massentro,up_massdetro,up_massentru,up_massdetru)

--- a/physics/cu_gf_driver.F90
+++ b/physics/cu_gf_driver.F90
@@ -927,38 +927,6 @@ contains
               !gdc(i,k,8)=(outq(i,k))*86400.*xlv/cp
                gdc(i,k,8)=(outqm(i,k)+outqs(i,k)+outq(i,k))*86400.*xlv/cp
                gdc(i,k,9)=gdc(i,k,2)+gdc(i,k,3)+gdc(i,k,4)
-!
-!> - Calculate subsidence effect on clw
-!
-!              dsubclw=0.
-!              dsubclwm=0.
-!              dsubclws=0.
-!              dp=100.*(p2d(i,k)-p2d(i,k+1))
-!              if (clcw(i,k) .gt. -999.0 .and. clcw(i,k+1) .gt. -999.0 )then
-!                 clwtot = cliw(i,k) + clcw(i,k)
-!                 clwtot1= cliw(i,k+1) + clcw(i,k+1)
-!                 dsubclw=((-edt(i)*zd(i,k+1)+zu(i,k+1))*clwtot1   &
-!                      -(-edt(i)*zd(i,k)  +zu(i,k))  *clwtot  )*g/dp
-!                 dsubclwm=((-edtm(i)*zdm(i,k+1)+zum(i,k+1))*clwtot1   &
-!                      -(-edtm(i)*zdm(i,k)  +zum(i,k))  *clwtot  )*g/dp
-!                 dsubclws=(zus(i,k+1)*clwtot1-zus(i,k)*clwtot)*g/dp
-!                 dsubclw=dsubclw+(zu(i,k+1)*clwtot1-zu(i,k)*clwtot)*g/dp
-!                 dsubclwm=dsubclwm+(zum(i,k+1)*clwtot1-zum(i,k)*clwtot)*g/dp
-!                 dsubclws=dsubclws+(zus(i,k+1)*clwtot1-zus(i,k)*clwtot)*g/dp
-!              endif
-!              tem  = dt*(outqcs(i,k)*cutens(i)+outqc(i,k)*cuten(i)       &
-!                    +outqcm(i,k)*cutenm(i)                           &
-!                     +dsubclw*xmb(i)+dsubclws*xmbs(i)+dsubclwm*xmbm(i) &
-!                    )
-!              tem1 = max(0.0, min(1.0, (tcr-t(i,k))*tcrf))
-!              if (clcw(i,k) .gt. -999.0) then
-!               cliw(i,k) = max(0.,cliw(i,k) + tem * tem1)            ! ice
-!               clcw(i,k) = max(0.,clcw(i,k) + tem *(1.0-tem1))       ! water
-!              else
-!                cliw(i,k) = max(0.,cliw(i,k) + tem)
-!              endif
-!
-!            enddo
 
 !> - FCT treats subsidence effect to cloud ice/water (begin)
                dp=100.*(p2d(i,k)-p2d(i,k+1))

--- a/physics/cu_gf_driver.F90
+++ b/physics/cu_gf_driver.F90
@@ -644,7 +644,6 @@ contains
      enddo
 !$acc end kernels
      if (dx(its)<6500.) then
-!       ichoice=10
        imid_gf=0
      endif
 !
@@ -1015,8 +1014,8 @@ contains
             gdc(i,16,10)=pret(i)*3600.
 
             maxupmf(i)=0.
-            if(forcing(i,6).gt.0.)then
-              maxupmf(i)=maxval(xmb(i)*zu(i,kts:ktf)/forcing(i,6))
+            if(forcing2(i,6).gt.0.)then
+              maxupmf(i)=maxval(xmb(i)*zu(i,kts:ktf)/forcing2(i,6))
             endif
 
             if(ktop(i).gt.2 .and.pret(i).gt.0.)dt_mf(i,ktop(i)-1)=ud_mf(i,ktop(i))

--- a/physics/cu_gf_driver_post.F90
+++ b/physics/cu_gf_driver_post.F90
@@ -66,7 +66,6 @@ module cu_gf_driver_post
           conv_act_m(i)=0.0
         endif
         ! reflectivity parameterization for parameterized convection (reference:Unipost MDLFLD.f)
-        !if(sqrt(garea(i)).lt.6500.)then
         ze      = 0.0
         ze_conv = 0.0
         dbz_sum = 0.0
@@ -80,7 +79,6 @@ module cu_gf_driver_post
           refl_10cm(i,k) = dbz_sum
          enddo
         endif
-        !endif
       enddo
 !$acc end kernels
 

--- a/physics/cu_gf_driver_post.F90
+++ b/physics/cu_gf_driver_post.F90
@@ -69,7 +69,7 @@ module cu_gf_driver_post
         ze      = 0.0
         ze_conv = 0.0
         dbz_sum = 0.0
-        cuprate = max(0.1,1.e3*raincv(i) * 3600.0 / dt)          ! cu precip rate (mm/h)
+        cuprate = 1.e3*raincv(i) * 3600.0 / dt          ! cu precip rate (mm/h)
         if(cuprate .lt. 0.05) cuprate=0.
         ze_conv = 300.0 * cuprate**1.5
         if (maxupmf(i).gt.0.1 .and. cuprate.gt.0.) then

--- a/physics/cu_gf_driver_post.F90
+++ b/physics/cu_gf_driver_post.F90
@@ -66,20 +66,21 @@ module cu_gf_driver_post
           conv_act_m(i)=0.0
         endif
         ! reflectivity parameterization for parameterized convection (reference:Unipost MDLFLD.f)
-        if(sqrt(garea(i)).lt.6500.)then
+        !if(sqrt(garea(i)).lt.6500.)then
         ze      = 0.0
         ze_conv = 0.0
         dbz_sum = 0.0
-        cuprate = raincv(i) * 3600.0 / dt          ! cu precip rate (mm/h)
-        ze_conv = 300.0 * cuprate**1.4
-        if (maxupmf(i).gt.0.05) then
+        cuprate = max(0.1,1.e3*raincv(i) * 3600.0 / dt)          ! cu precip rate (mm/h)
+        if(cuprate .lt. 0.05) cuprate=0.
+        ze_conv = 300.0 * cuprate**1.5
+        if (maxupmf(i).gt.0.1 .and. cuprate.gt.0.) then
          do k = 1, km
           ze = 10._kind_phys ** (0.1 * refl_10cm(i,k))
           dbz_sum = max(dbzmin, 10.0 * log10(ze + ze_conv))
           refl_10cm(i,k) = dbz_sum
          enddo
         endif
-        endif
+        !endif
       enddo
 !$acc end kernels
 

--- a/physics/noahmp_tables.f90
+++ b/physics/noahmp_tables.f90
@@ -783,7 +783,7 @@ rsurf_snow_table     = -1.0e36
        open(15, status='old', form='formatted', action='read', iostat=ierr)
     end if
     if ( ierr /= 0 ) then
-       errmsg = 'warning: cannot find file noahmptable.tb'
+       errmsg = 'warning: cannot find file noahmptable.tbl'
        errflg = 1
        return
 !      write(*,'("warning: cannot find file noahmptable.tbl")')
@@ -914,7 +914,7 @@ rsurf_snow_table     = -1.0e36
        open(15, status='old', form='formatted', action='read', iostat=ierr)
     end if
     if ( ierr /= 0 ) then
-       errmsg = 'warning: cannot find file noahmptable.tb'
+       errmsg = 'warning: cannot find file noahmptable.tbl'
        errflg = 1
        return
 !      write(*,'("warning: cannot find file noahmptable.tbl")')
@@ -957,7 +957,7 @@ rsurf_snow_table     = -1.0e36
        open(15, status='old', form='formatted', action='read', iostat=ierr)
     end if
     if ( ierr /= 0 ) then
-       errmsg = 'warning: cannot find file noahmptable.tb'
+       errmsg = 'warning: cannot find file noahmptable.tbl'
        errflg = 1
        return
 !      write(*,'("warning: cannot find file noahmptable.tbl")')
@@ -982,7 +982,7 @@ rsurf_snow_table     = -1.0e36
       open(15, status='old', form='formatted', action='read', iostat=ierr)
     end if
     if (ierr /= 0) then
-       errmsg = 'warning: cannot find file noahmptable.tb'
+       errmsg = 'warning: cannot find file noahmptable.tbl'
        errflg = 1
        return
 !      write(*,'("warning: cannot find file noahmptable.tbl")')
@@ -1011,7 +1011,7 @@ rsurf_snow_table     = -1.0e36
       open(15, status='old', form='formatted', action='read', iostat=ierr)
     end if
     if (ierr /= 0) then
-       errmsg = 'warning: cannot find file noahmptable.tb'
+       errmsg = 'warning: cannot find file noahmptable.tbl'
        errflg = 1
        return
 !      write(*,'("warning: cannot find file noahmptable.tbl")')
@@ -1069,7 +1069,7 @@ rsurf_snow_table     = -1.0e36
       open(15, status='old', form='formatted', action='read', iostat=ierr)
     end if
     if (ierr /= 0) then
-       errmsg = 'warning: cannot find file noahmptable.tb'
+       errmsg = 'warning: cannot find file noahmptable.tbl'
        errflg = 1
        return
 !      write(*,'("warning: cannot find file noahmptable.tbl")')
@@ -1096,7 +1096,7 @@ rsurf_snow_table     = -1.0e36
       open(15, status='old', form='formatted', action='read', iostat=ierr)
     end if
     if (ierr /= 0) then
-       errmsg = 'warning: cannot find file noahmptable.tb'
+       errmsg = 'warning: cannot find file noahmptable.tbl'
        errflg = 1
        return
 !      write(*,'("warning: cannot find file noahmptable.tbl")')
@@ -1249,7 +1249,7 @@ rsurf_snow_table     = -1.0e36
       open(15, status='old', form='formatted', action='read', iostat=ierr)
     end if
     if (ierr /= 0) then
-       errmsg = 'warning: cannot find file noahmptable.tb'
+       errmsg = 'warning: cannot find file noahmptable.tbl'
        errflg = 1
        return
 !      write(*,'("warning: cannot find file noahmptable.tbl")')
@@ -1278,7 +1278,7 @@ rsurf_snow_table     = -1.0e36
       open(15, status='old', form='formatted', action='read', iostat=ierr)
     end if
     if (ierr /= 0) then
-       errmsg = 'warning: cannot find file noahmptable.tb'
+       errmsg = 'warning: cannot find file noahmptable.tbl'
        errflg = 1
        return
 !      write(*,'("warning: cannot find file noahmptable.tbl")')

--- a/physics/noahmp_tables.f90
+++ b/physics/noahmp_tables.f90
@@ -484,6 +484,9 @@ contains
                                                       sr2006_psi_e_a, sr2006_psi_e_b, sr2006_psi_e_c, sr2006_smcmax_a,       &
                                                       sr2006_smcmax_b
 
+    errmsg = ''
+    errflg = 0
+
     ! initialize our variables to bad values, so that if the namelist read fails, we come to a screeching halt as soon as we try to use anything.
     ! vegetation parameters
     isurban_table      = -99999

--- a/physics/set_soilveg.f
+++ b/physics/set_soilveg.f
@@ -44,6 +44,9 @@
      &  DEFINED_SLOPE, FXEXP_DATA, NROOT_DATA, REFKDT_DATA, Z0_DATA,
      &  CZIL_DATA, LAI_DATA, CSOIL_DATA
 
+      errmsg = ''
+      errflg = 0
+
 cmy end locals
       if(ivet.eq.2) then
 

--- a/physics/smoke_dust/dust_data_mod.F90
+++ b/physics/smoke_dust/dust_data_mod.F90
@@ -44,24 +44,10 @@ module dust_data_mod
   ! Never used:
   ! real(kind_phys), parameter :: fengsha_alpha = 0.3
   ! real(kind_phys), parameter :: fengsha_gamma = 1.3
+
   ! -- FENGSHA threshold velocities based on Dale A. Gillette's data
   integer, parameter :: fengsha_maxstypes = 13
-!  real(kind_phys), dimension(fengsha_maxstypes) :: dust_uthres = &
-!    (/ 0.065,   & ! Sand            - 1
-!       0.20,    & ! Loamy Sand      - 2
-!       0.52,    & ! Sandy Loam      - 3
-!       0.50,    & ! Silt Loam       - 4
-!       0.50,    & ! Silt            - 5
-!       0.60,    & ! Loam            - 6
-!       0.73,    & ! Sandy Clay Loam - 7
-!       0.73,    & ! Silty Clay Loam - 8
-!       0.80,    & ! Clay Loam       - 9
-!       0.95,    & ! Sandy Clay      - 10
-!       0.95,    & ! Silty Clay      - 11
-!       1.00,    & ! Clay            - 12
-!       9.999 /)   ! Other           - 13
-!  dust_uthres = 0.065, 0.18, 0.27, 0.30, 0.35, 0.38, 0.35, 0.41, 0.41,
-!                0.45,0.50,0.45,9999.0
+
   real(kind_phys), dimension(fengsha_maxstypes), parameter :: dust_uthres = &
     (/ 0.065,   & ! Sand            - 1
        0.18,    & ! Loamy Sand      - 2
@@ -76,12 +62,16 @@ module dust_data_mod
        0.50,    & ! Silty Clay      - 11
        0.45,    & ! Clay            - 12
        9999.0 /)   ! Other           - 13
-  ! -- FENGSHA uses precalculated drag partition from ASCAT. See: Prigent et al. (2012,2015)
+
+  ! -- FENGSHA uses precalculated drag partition
   integer, parameter :: dust_calcdrag = 1
-
-  real(kind_phys) :: dust_alpha = 2.2
+  ! -- FENGSHA dust moisture parameterization 1:fecan  -  2:shao 
+  integer :: dust_moist_opt = 1
+  
+  real(kind_phys) :: dust_alpha = 1.0
   real(kind_phys) :: dust_gamma = 1.0
-
+  real(kind_phys) :: dust_moist_correction = 1.0
+  real(kind_phys) :: dust_drylimit_factor = 1.0
 
   ! -- sea salt parameters
   integer,            dimension(nsalt), parameter :: spoint    = (/ 1, 2, 2, 2, 2, 2, 3, 3, 3 /)  ! 1 Clay, 2 Silt, 3 Sand
@@ -93,7 +83,7 @@ module dust_data_mod
     (/      1.,     0.2,     0.2,     0.2,     0.2,     0.2,   0.333,   0.333,   0.333 /)
 
 
-  ! -- soil vagatation parameters
+  ! -- soil vegatation parameters
   integer, parameter :: max_soiltyp = 30
   real(kind_phys), dimension(max_soiltyp), parameter :: &
     maxsmc = (/ 0.421, 0.464, 0.468, 0.434, 0.406, 0.465, &

--- a/physics/smoke_dust/rrfs_smoke_wrapper.F90
+++ b/physics/smoke_dust/rrfs_smoke_wrapper.F90
@@ -12,7 +12,8 @@
                                      num_moist, num_chem, num_emis_seas, num_emis_dust, &
                                      DUST_OPT_FENGSHA, p_qv, p_atm_shum, p_atm_cldq,    &
                                      p_smoke, p_dust_1, p_coarse_pm, epsilc
-   use dust_data_mod,         only : dust_alpha, dust_gamma
+   use dust_data_mod,         only : dust_alpha, dust_gamma, dust_moist_opt, &
+                                     dust_moist_correction, dust_drylimit_factor
    use plume_data_mod,        only : p_frp_std, p_frp_hr, num_frp_plume
    use seas_mod,              only : gocart_seasalt_driver
    use dust_fengsha_mod,      only : gocart_dust_fengsha_driver
@@ -49,6 +50,7 @@ contains
                    ebb_smoke_hr, frp_hr, frp_std_hr,                                       &
                    coef_bb, ebu_smoke,fhist, min_fplume, max_fplume, hwp, wetness,         &
                    smoke_ext, dust_ext, ndvel, ddvel_inout,rrfs_sd,                        &
+                   dust_moist_opt_in, dust_moist_correction_in, dust_drylimit_factor_in,   & 
                    dust_alpha_in, dust_gamma_in, fire_in,                                  &
                    seas_opt_in, dust_opt_in, drydep_opt_in, coarsepm_settling_in,          &
                    do_plumerise_in, plumerisefire_frq_in, addsmoke_flag_in,                &
@@ -91,12 +93,15 @@ contains
     real(kind_phys), dimension(:,:), intent(out) :: smoke_ext, dust_ext
     real(kind_phys), dimension(:,:), intent(inout) :: nwfa, nifa
     real(kind_phys), dimension(:,:), intent(inout) :: ddvel_inout
-    real (kind=kind_phys), dimension(:), intent(in) :: wetness
-    integer, intent(in   ) :: imp_physics, imp_physics_thompson
-    real (kind=kind_phys), intent(in) :: dust_alpha_in, dust_gamma_in, wetdep_ls_alpha_in
-    integer,        intent(in) :: seas_opt_in, dust_opt_in, drydep_opt_in,        &
-                                  coarsepm_settling_in, plumerisefire_frq_in,     &
-                                  addsmoke_flag_in, wetdep_ls_opt_in
+    real(kind_phys), dimension(:), intent(in) :: wetness
+    real(kind_phys), intent(in) :: dust_alpha_in, dust_gamma_in, wetdep_ls_alpha_in
+    real(kind_phys), intent(in) :: dust_moist_correction_in
+    real(kind_phys), intent(in) :: dust_drylimit_factor_in
+    integer, intent(in) :: dust_moist_opt_in
+    integer, intent(in) :: imp_physics, imp_physics_thompson
+    integer, intent(in) :: seas_opt_in, dust_opt_in, drydep_opt_in,        &
+                           coarsepm_settling_in, plumerisefire_frq_in,     &
+                           addsmoke_flag_in, wetdep_ls_opt_in
     logical, intent(in   ) :: do_plumerise_in, rrfs_sd
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errflg
@@ -314,6 +319,9 @@ contains
        ! Set at compile time in dust_data_mod:
        dust_alpha = dust_alpha_in
        dust_gamma = dust_gamma_in
+       dust_moist_opt = dust_moist_opt_in
+       dust_moist_correction = dust_moist_correction_in
+       dust_drylimit_factor = dust_drylimit_factor_in
        call gocart_dust_fengsha_driver(dt,chem,rho_phy,smois,p8w,ssm,   &
             isltyp,vegfrac,snowh,xland,dxy,g,emis_dust,ust,znt,         &
             clayf,sandf,rdrag,uthr,                                     &

--- a/physics/smoke_dust/rrfs_smoke_wrapper.meta
+++ b/physics/smoke_dust/rrfs_smoke_wrapper.meta
@@ -220,7 +220,7 @@
   standard_name = volume_fraction_of_soil_moisture_for_land_surface_model
   long_name = volumetric fraction of soil moisture for lsm
   units = frac
-  dimensions = (horizontal_dimension,vertical_dimension_of_soil_internal_to_land_surface_scheme)
+  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
   intent = inout

--- a/physics/smoke_dust/rrfs_smoke_wrapper.meta
+++ b/physics/smoke_dust/rrfs_smoke_wrapper.meta
@@ -210,17 +210,17 @@
   kind = kind_phys
   intent = in
 [nsoil]
-  standard_name = vertical_dimension_of_soil
-  long_name = soil vertical layer dimension
+  standard_name = vertical_dimension_of_soil_internal_to_land_surface_scheme
+  long_name = number of soil layers internal to land surface model
   units = count
   dimensions = ()
   type = integer
   intent = in
 [smc]
-  standard_name = volume_fraction_of_condensed_water_in_soil
-  long_name = volumetric fraction of soil moisture
+  standard_name = volume_fraction_of_soil_moisture_for_land_surface_model
+  long_name = volumetric fraction of soil moisture for lsm
   units = frac
-  dimensions = (horizontal_loop_extent,vertical_dimension_of_soil)
+  dimensions = (horizontal_dimension,vertical_dimension_of_soil_internal_to_land_surface_scheme)
   type = real
   kind = kind_phys
   intent = inout
@@ -611,6 +611,32 @@
   units = flag
   dimensions = ()
   type = logical
+  intent = in
+[dust_moist_opt_in]
+  standard_name = control_for_dust_soil_moisture_option
+  long_name = smoke dust moisture parameterization 1 - fecan 2 - shao
+  units = index
+  dimensions = ()
+  type = integer
+  active = (do_smoke_coupling)
+  intent = in
+[dust_moist_correction_in]
+  standard_name = dust_moist_correction_fengsha_dust_scheme
+  long_name = moisture correction term for fengsha dust emission
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
+  intent = in
+[dust_drylimit_factor_in]
+  standard_name = dust_drylimit_factor_fengsha_dust_scheme
+  long_name = moisture correction term for drylimit in fengsha dust emission
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  active = (do_smoke_coupling)
   intent = in
 [dust_alpha_in]
   standard_name = alpha_fengsha_dust_scheme


### PR DESCRIPTION
The c3 code cannot handle null pointers correctly. This changes some array argument declarations so tests pass. At the ufs-weather-model level, I've added hrrr_c3_debug tests for both the gnu and intel compilers. The new tests pass on Jet, Hera, and Cheyenne.

This PR includes #113 and #106 

- Fixes #112
- Fixes #101
- Fixes #108
- Fixes #107
- Fixes #105
- Fixes #104 
- Adds `errflg=0` and `errmsg=''` in two routines that were missing them.