### PR TITLE
passing nc back from microphysics

### DIFF
--- a/physics/module_mp_thompson.F90
+++ b/physics/module_mp_thompson.F90
@@ -1509,6 +1509,14 @@ MODULE module_mp_thompson
             enddo
          endif
 
+         if (merra2_aerosol_aware) then
+            do k = kts, kte
+               nc(i,k,j) = nc1d(k)
+               nwfa(i,k,j) = nwfa1d(k)
+               nifa(i,k,j) = nifa1d(k)
+            enddo
+         endif
+
          do k = kts, kte
             qv(i,k,j) = qv1d(k)
             qc(i,k,j) = qc1d(k)


### PR DESCRIPTION
passing nc back from microphysics is the main reason for the bug fixing, pass nifa and nwfa back is more or less for diagnostic purpose