### PR TITLE
Address compliance issues towards NCO HPC implementation standards for AQMv7 operational implementation

### DIFF
--- a/physics/GFS_DCNV_generic_post.F90
+++ b/physics/GFS_DCNV_generic_post.F90
@@ -41,7 +41,7 @@
       real(kind=kind_phys), dimension(:,:), intent(inout) :: upd_mf, dwn_mf, det_mf
       real(kind=kind_phys), dimension(:,:), intent(inout) :: cnvw, cnvc
 
-      real(kind=kind_phys), dimension(:,:,:), intent(inout) :: dtend
+      real(kind=kind_phys), dimension(:,:,:), pointer       :: dtend
       integer, intent(in) :: dtidx(:,:), index_of_process_dcnv, index_of_temperature, &
            index_of_x_wind, index_of_y_wind, ntqv
       integer, intent(in) :: ntcw,ntiw,ntclamt,ntrw,ntsw,ntrnc,ntsnc,ntgl,   &

--- a/physics/GFS_DCNV_generic_post.F90
+++ b/physics/GFS_DCNV_generic_post.F90
@@ -38,7 +38,7 @@
       logical, intent(in) :: satmedmf, trans_trac
 
       real(kind=kind_phys), dimension(:),   intent(inout) :: rainc, cldwrk
-      real(kind=kind_phys), dimension(:,:), intent(inout) :: upd_mf, dwn_mf, det_mf
+      real(kind=kind_phys), dimension(:,:), pointer       :: upd_mf, dwn_mf, det_mf
       real(kind=kind_phys), dimension(:,:), intent(inout) :: cnvw, cnvc
 
       real(kind=kind_phys), dimension(:,:,:), pointer       :: dtend

--- a/physics/GFS_GWD_generic_post.F90
+++ b/physics/GFS_GWD_generic_post.F90
@@ -27,7 +27,7 @@ contains
       real(kind=kind_phys), intent(inout) :: dugwd(:), dvgwd(:)
 
       ! dtend only allocated only if ldiag3d is .true.
-      real(kind=kind_phys), intent(inout) :: dtend(:,:,:)
+      real(kind=kind_phys), pointer       :: dtend(:,:,:)
       integer, intent(in) :: dtidx(:,:), index_of_temperature,          &
      &  index_of_x_wind, index_of_y_wind, index_of_process_orographic_gwd
       

--- a/physics/GFS_GWD_generic_pre.F90
+++ b/physics/GFS_GWD_generic_pre.F90
@@ -28,13 +28,14 @@ contains
 
       real(kind=kind_phys), intent(out) ::                              &
      &  oc(:), oa4(:,:), clx(:,:),                                      &
-     &  varss(:), ocss(:), oa4ss(:,:), clxss(:,:),                      &
      &  theta(:), sigma(:), gamma(:), elvmax(:)
+      real(kind=kind_phys), pointer     ::                              &
+     &  varss(:), ocss(:), oa4ss(:,:), clxss(:,:)
 
       logical, intent(in) :: lssav, ldiag3d, flag_for_gwd_generic_tend
       real(kind=kind_phys), intent(in) :: dtdt(:,:), dudt(:,:), dvdt(:,:)
       ! dtend only allocated only if ldiag3d is .true.
-      real(kind=kind_phys), intent(inout) :: dtend(:,:,:)
+      real(kind=kind_phys), pointer       :: dtend(:,:,:)
       integer, intent(in) :: dtidx(:,:), index_of_temperature,          &
      &  index_of_x_wind, index_of_y_wind, index_of_process_orographic_gwd
       real(kind=kind_phys), intent(in) :: dtf

--- a/physics/GFS_MP_generic_post.F90
+++ b/physics/GFS_MP_generic_post.F90
@@ -55,7 +55,7 @@
       real(kind=kind_phys), dimension(:,:),    intent(in)    :: prsi, phii
       real(kind=kind_phys), dimension(:,:,:),  intent(in)    :: gq0, save_q
 
-      real(kind=kind_phys), dimension(:,:,:),  intent(in)    :: dfi_radar_tten
+      real(kind=kind_phys), dimension(:,:,:),  pointer       :: dfi_radar_tten
 
       real(kind=kind_phys), dimension(:),      intent(in   ) :: sr
       real(kind=kind_phys), dimension(:),      intent(inout) :: rain, domr_diag, domzr_diag, domip_diag, doms_diag, tprcp,  &
@@ -63,7 +63,7 @@
                                                                 totprcpb, toticeb, totsnwb, totgrpb, pwat
       real(kind=kind_phys), dimension(:),      intent(inout) :: rain_cpl, rainc_cpl, snow_cpl
 
-      real(kind=kind_phys), dimension(:,:,:),   intent(inout) :: dtend
+      real(kind=kind_phys), dimension(:,:,:),  pointer       :: dtend
       integer,         dimension(:,:), intent(in)    :: dtidx
 
       ! Stochastic physics / surface perturbations
@@ -71,17 +71,17 @@
 
       ! Rainfall variables previous time step
       integer, intent(in) :: lsm, lsm_ruc, lsm_noahmp
-      real(kind=kind_phys), dimension(:),      intent(inout) :: raincprv
-      real(kind=kind_phys), dimension(:),      intent(inout) :: rainncprv
-      real(kind=kind_phys), dimension(:),      intent(inout) :: iceprv
-      real(kind=kind_phys), dimension(:),      intent(inout) :: snowprv
-      real(kind=kind_phys), dimension(:),      intent(inout) :: graupelprv
-      real(kind=kind_phys), dimension(:),      intent(inout) :: draincprv
-      real(kind=kind_phys), dimension(:),      intent(inout) :: drainncprv
-      real(kind=kind_phys), dimension(:),      intent(inout) :: diceprv
-      real(kind=kind_phys), dimension(:),      intent(inout) :: dsnowprv
-      real(kind=kind_phys), dimension(:),      intent(inout) :: dgraupelprv
-      real(kind=kind_phys), dimension(:,:),    intent(inout) :: dqdt_qmicro
+      real(kind=kind_phys), dimension(:),      pointer       :: raincprv
+      real(kind=kind_phys), dimension(:),      pointer       :: rainncprv
+      real(kind=kind_phys), dimension(:),      pointer       :: iceprv
+      real(kind=kind_phys), dimension(:),      pointer       :: snowprv
+      real(kind=kind_phys), dimension(:),      pointer       :: graupelprv
+      real(kind=kind_phys), dimension(:),      pointer       :: draincprv
+      real(kind=kind_phys), dimension(:),      pointer       :: drainncprv
+      real(kind=kind_phys), dimension(:),      pointer       :: diceprv
+      real(kind=kind_phys), dimension(:),      pointer       :: dsnowprv
+      real(kind=kind_phys), dimension(:),      pointer       :: dgraupelprv
+      real(kind=kind_phys), dimension(:,:),    pointer       :: dqdt_qmicro
       real(kind=kind_phys), dimension(:,:),    intent(inout) :: prevsq
       real(kind=kind_phys),                    intent(in)    :: dtp
 

--- a/physics/GFS_PBL_generic_post.F90
+++ b/physics/GFS_PBL_generic_post.F90
@@ -47,8 +47,9 @@
       real(kind=kind_phys), intent(in) :: rd, cp, fvirt, hvap, huge
       real(kind=kind_phys), dimension(:), intent(in) :: t1, q1, hflx, oceanfrac
       real(kind=kind_phys), dimension(:,:), intent(in) :: prsl
-      real(kind=kind_phys), dimension(:), intent(in) :: dusfc_cice, dvsfc_cice, dtsfc_cice, dqsfc_cice, &
-          dtsfc_med, dqsfc_med, dusfc_med, dvsfc_med, wind, stress_wat, hflx_wat, evap_wat, ugrs1, vgrs1
+      real(kind=kind_phys), dimension(:), pointer    :: dusfc_cice, dvsfc_cice, dtsfc_cice, dqsfc_cice, &
+          dtsfc_med, dqsfc_med, dusfc_med, dvsfc_med
+      real(kind=kind_phys), dimension(:), intent(in) :: wind, stress_wat, hflx_wat, evap_wat, ugrs1, vgrs1
 
       real(kind=kind_phys), dimension(:,:, :), intent(in) :: qgrs
       real(kind=kind_phys), dimension(:,:), intent(in) :: ugrs, vgrs, tgrs
@@ -63,9 +64,9 @@
       ! Since Intel 15 crashes when passing unallocated arrays to arrays defined with explicit shape,
       ! use assumed-shape arrays. Note that Intel 18 and GNU 6.2.0-8.1.0 tolerate explicit-shape arrays
       ! as long as these do not get used when not allocated.
-      real(kind=kind_phys), dimension(:),   intent(inout) :: dusfc_cpl, dvsfc_cpl, dtsfc_cpl, dqsfc_cpl, dusfci_cpl, dvsfci_cpl, &
+      real(kind=kind_phys), dimension(:),   pointer       :: dusfc_cpl, dvsfc_cpl, dtsfc_cpl, dqsfc_cpl, dusfci_cpl, dvsfci_cpl, &
         dtsfci_cpl, dqsfci_cpl, dusfc_diag, dvsfc_diag, dtsfc_diag, dqsfc_diag, dusfci_diag, dvsfci_diag, dtsfci_diag, dqsfci_diag
-      real(kind=kind_phys), intent(inout), optional :: dtend(:,:,:)
+      real(kind=kind_phys), pointer      , optional :: dtend(:,:,:)
       integer, intent(in) :: dtidx(:,:)
       integer, intent(in) :: index_of_temperature, index_of_x_wind, index_of_y_wind, index_of_process_pbl
 

--- a/physics/GFS_SCNV_generic_post.F90
+++ b/physics/GFS_SCNV_generic_post.F90
@@ -31,7 +31,7 @@
       real(kind=kind_phys), dimension(:,:,:),   intent(in) :: save_q, gq0
 
       ! dtend only allocated if ldiag3d == .true.
-      real(kind=kind_phys), intent(inout) :: dtend(:,:,:)
+      real(kind=kind_phys), pointer       :: dtend(:,:,:)
       integer, intent(in) :: dtidx(:,:)
       integer, intent(in) :: index_of_temperature, index_of_x_wind, index_of_y_wind, index_of_process_scnv
       real(kind=kind_phys), dimension(:,:,:), intent(in) :: clw

--- a/physics/GFS_phys_time_vary.fv3.F90
+++ b/physics/GFS_phys_time_vary.fv3.F90
@@ -86,93 +86,99 @@
          implicit none
 
          ! Interface variables
-         integer,              intent(in)    :: me, master, ntoz, iccn, iflip, im, nx, ny, levs
-         logical,              intent(in)    :: h2o_phys, iaerclm, lsm_cold_start
-         integer,              intent(in)    :: idate(:)
-         real(kind_phys),      intent(in)    :: fhour
-         real(kind_phys),      intent(in)    :: xlat_d(:), xlon_d(:)
+         integer,                           intent(in)    :: me, master, ntoz, iccn, iflip, im, nx, ny, levs
+         logical,                           intent(in)    :: h2o_phys, iaerclm, lsm_cold_start
+         integer,                           intent(in)    :: idate(:)
+         real(kind_phys),                   intent(in)    :: fhour
+         real(kind_phys),      allocatable, intent(in)    :: xlat_d(:), xlon_d(:)
 
-         integer,              intent(inout) :: jindx1_o3(:), jindx2_o3(:), jindx1_h(:), jindx2_h(:)
-         real(kind_phys),      intent(inout) :: ddy_o3(:),  ddy_h(:)
-         real(kind_phys),      intent(in)    :: ozpl(:,:,:), h2opl(:,:,:)
-         integer,              intent(inout) :: jindx1_aer(:), jindx2_aer(:), iindx1_aer(:), iindx2_aer(:)
-         real(kind_phys),      intent(inout) :: ddy_aer(:), ddx_aer(:)
-         real(kind_phys),      intent(out)   :: aer_nm(:,:,:)
-         integer,              intent(inout) :: jindx1_ci(:), jindx2_ci(:), iindx1_ci(:), iindx2_ci(:)
-         real(kind_phys),      intent(inout) :: ddy_ci(:), ddx_ci(:)
-         integer,              intent(inout) :: imap(:), jmap(:)
-         logical,              intent(in)    :: do_ugwp_v1
-         real(kind_phys),      intent(inout) :: ddy_j1tau(:), ddy_j2tau(:)
-         integer,              intent(inout) :: jindx1_tau(:), jindx2_tau(:)
+         integer,              allocatable, intent(inout) :: jindx1_o3(:), jindx2_o3(:), jindx1_h(:), jindx2_h(:)
+         real(kind_phys),      allocatable, intent(inout) :: ddy_o3(:),  ddy_h(:)
+         real(kind_phys),      allocatable, intent(in)    :: ozpl(:,:,:), h2opl(:,:,:)
+         integer,              allocatable, intent(inout) :: jindx1_aer(:), jindx2_aer(:), iindx1_aer(:), iindx2_aer(:)
+         real(kind_phys),      allocatable, intent(inout) :: ddy_aer(:), ddx_aer(:)
+         real(kind_phys),      allocatable, intent(inout) :: aer_nm(:,:,:)
+         integer,              allocatable, intent(inout) :: jindx1_ci(:), jindx2_ci(:), iindx1_ci(:), iindx2_ci(:)
+         real(kind_phys),      allocatable, intent(inout) :: ddy_ci(:), ddx_ci(:)
+         integer,              allocatable, intent(inout) :: imap(:), jmap(:)
+         logical,                           intent(in)    :: do_ugwp_v1
+         real(kind_phys),      allocatable, intent(inout) :: ddy_j1tau(:), ddy_j2tau(:)
+         integer,              allocatable, intent(inout) :: jindx1_tau(:), jindx2_tau(:)
 
-         integer,              intent(in)    :: isot, ivegsrc, nlunit
-         real(kind_phys),      intent(inout) :: sncovr(:), sncovr_ice(:)
-         integer,              intent(in)    :: lsm, lsm_noahmp, lsm_ruc, vtype(:)
-         real(kind_phys),      intent(in)    :: min_seaice, fice(:)
-         real(kind_phys),      intent(in)    :: landfrac(:)
-         real(kind_phys),      intent(inout) :: weasd(:)
+         integer,                           intent(in)    :: isot, ivegsrc, nlunit
+         real(kind_phys),      allocatable, intent(inout) :: sncovr(:), sncovr_ice(:)
+         integer,                           intent(in)    :: lsm, lsm_noahmp, lsm_ruc
+         integer,              allocatable, intent(in)    :: vtype(:)
+         real(kind_phys),                   intent(in)    :: min_seaice
+         real(kind_phys),      allocatable, intent(in)    :: fice(:)
+         real(kind_phys),      allocatable, intent(in)    :: landfrac(:)
+         real(kind_phys),      allocatable, intent(inout) :: weasd(:)
 
          ! NoahMP - only allocated when NoahMP is used
-         integer, intent(in) :: lsoil, lsnow_lsm_lbound, lsnow_lsm_ubound
-         real(kind_phys),      intent(in)    :: zs(:)
-         real(kind_phys),      intent(in)    :: dzs(:)
-         real(kind_phys),      intent(inout) :: tvxy(:)
-         real(kind_phys),      intent(inout) :: tgxy(:)
-         real(kind_phys),      intent(inout) :: tahxy(:)
-         real(kind_phys),      intent(inout) :: canicexy(:)
-         real(kind_phys),      intent(inout) :: canliqxy(:)
-         real(kind_phys),      intent(inout) :: eahxy(:)
-         real(kind_phys),      intent(inout) :: cmxy(:)
-         real(kind_phys),      intent(inout) :: chxy(:)
-         real(kind_phys),      intent(inout) :: fwetxy(:)
-         real(kind_phys),      intent(inout) :: sneqvoxy(:)
-         real(kind_phys),      intent(inout) :: alboldxy(:)
-         real(kind_phys),      intent(inout) :: qsnowxy(:)
-         real(kind_phys),      intent(inout) :: wslakexy(:)
-         real(kind_phys),      intent(inout) :: albdvis_lnd(:)
-         real(kind_phys),      intent(inout) :: albdnir_lnd(:)
-         real(kind_phys),      intent(inout) :: albivis_lnd(:)
-         real(kind_phys),      intent(inout) :: albinir_lnd(:)
-         real(kind_phys),      intent(inout) :: albdvis_ice(:)
-         real(kind_phys),      intent(inout) :: albdnir_ice(:)
-         real(kind_phys),      intent(inout) :: albivis_ice(:)
-         real(kind_phys),      intent(inout) :: albinir_ice(:)
-         real(kind_phys),      intent(inout) :: emiss_lnd(:)
-         real(kind_phys),      intent(inout) :: emiss_ice(:)
-         real(kind_phys),      intent(inout) :: taussxy(:)
-         real(kind_phys),      intent(inout) :: waxy(:)
-         real(kind_phys),      intent(inout) :: wtxy(:)
-         real(kind_phys),      intent(inout) :: zwtxy(:)
-         real(kind_phys),      intent(inout) :: xlaixy(:)
-         real(kind_phys),      intent(inout) :: xsaixy(:)
-         real(kind_phys),      intent(inout) :: lfmassxy(:)
-         real(kind_phys),      intent(inout) :: stmassxy(:)
-         real(kind_phys),      intent(inout) :: rtmassxy(:)
-         real(kind_phys),      intent(inout) :: woodxy(:)
-         real(kind_phys),      intent(inout) :: stblcpxy(:)
-         real(kind_phys),      intent(inout) :: fastcpxy(:)
-         real(kind_phys),      intent(inout) :: smcwtdxy(:)
-         real(kind_phys),      intent(inout) :: deeprechxy(:)
-         real(kind_phys),      intent(inout) :: rechxy(:)
-         real(kind_phys),      intent(inout) :: snowxy(:)
-         real(kind_phys),      intent(inout) :: snicexy(:,lsnow_lsm_lbound:)
-         real(kind_phys),      intent(inout) :: snliqxy(:,lsnow_lsm_lbound:)
-         real(kind_phys),      intent(inout) :: tsnoxy (:,lsnow_lsm_lbound:)
-         real(kind_phys),      intent(inout) :: smoiseq(:,:)
-         real(kind_phys),      intent(inout) :: zsnsoxy(:,lsnow_lsm_lbound:)
-         real(kind_phys),      intent(inout) :: slc(:,:)
-         real(kind_phys),      intent(inout) :: smc(:,:)
-         real(kind_phys),      intent(inout) :: stc(:,:)
-         real(kind_phys),      intent(in)    :: tsfcl(:)
-         real(kind_phys),      intent(in)    :: snowd(:)
-         real(kind_phys),      intent(in)    :: canopy(:)
-         real(kind_phys),      intent(in)    :: tg3(:)
-         integer,              intent(in)    :: stype(:)
-         real(kind_phys),      intent(in)    :: con_t0c
+         integer,                           intent(in) :: lsoil, lsnow_lsm_lbound, lsnow_lsm_ubound
+         real(kind_phys),                   intent(in)    :: zs(:)
+         real(kind_phys),                   intent(in)    :: dzs(:)
+         real(kind_phys),      allocatable, intent(inout) :: tvxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: tgxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: tahxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: canicexy(:)
+         real(kind_phys),      allocatable, intent(inout) :: canliqxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: eahxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: cmxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: chxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: fwetxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: sneqvoxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: alboldxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: qsnowxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: wslakexy(:)
+         real(kind_phys),      allocatable, intent(inout) :: albdvis_lnd(:)
+         real(kind_phys),      allocatable, intent(inout) :: albdnir_lnd(:)
+         real(kind_phys),      allocatable, intent(inout) :: albivis_lnd(:)
+         real(kind_phys),      allocatable, intent(inout) :: albinir_lnd(:)
+         real(kind_phys),      allocatable, intent(inout) :: albdvis_ice(:)
+         real(kind_phys),      allocatable, intent(inout) :: albdnir_ice(:)
+         real(kind_phys),      allocatable, intent(inout) :: albivis_ice(:)
+         real(kind_phys),      allocatable, intent(inout) :: albinir_ice(:)
+         real(kind_phys),      allocatable, intent(inout) :: emiss_lnd(:)
+         real(kind_phys),      allocatable, intent(inout) :: emiss_ice(:)
+         real(kind_phys),      allocatable, intent(inout) :: taussxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: waxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: wtxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: zwtxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: xlaixy(:)
+         real(kind_phys),      allocatable, intent(inout) :: xsaixy(:)
+         real(kind_phys),      allocatable, intent(inout) :: lfmassxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: stmassxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: rtmassxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: woodxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: stblcpxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: fastcpxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: smcwtdxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: deeprechxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: rechxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: snowxy(:)
+         real(kind_phys),      allocatable, intent(inout) :: snicexy(:,:)
+         real(kind_phys),      allocatable, intent(inout) :: snliqxy(:,:)
+         real(kind_phys),      allocatable, intent(inout) :: tsnoxy (:,:)
+!        real(kind_phys),      allocatable, intent(inout) :: snicexy(:,lsnow_lsm_lbound:)
+!        real(kind_phys),      allocatable, intent(inout) :: snliqxy(:,lsnow_lsm_lbound:)
+!        real(kind_phys),      allocatable, intent(inout) :: tsnoxy (:,lsnow_lsm_lbound:)
+         real(kind_phys),      allocatable, intent(inout) :: smoiseq(:,:)
+         real(kind_phys),      allocatable, intent(inout) :: zsnsoxy(:,:)
+!        real(kind_phys),      allocatable, intent(inout) :: zsnsoxy(:,lsnow_lsm_lbound:)
+         real(kind_phys),      allocatable, intent(inout) :: slc(:,:)
+         real(kind_phys),      allocatable, intent(inout) :: smc(:,:)
+         real(kind_phys),      allocatable, intent(inout) :: stc(:,:)
+         real(kind_phys),      allocatable, intent(in)    :: tsfcl(:)
+         real(kind_phys),      allocatable, intent(in)    :: snowd(:)
+         real(kind_phys),      allocatable, intent(in)    :: canopy(:)
+         real(kind_phys),      allocatable, intent(in)    :: tg3(:)
+         integer,              allocatable, intent(in)    :: stype(:)
+         real(kind_phys),                   intent(in)    :: con_t0c
 
-         integer,              intent(in)    :: nthrds
-         character(len=*),     intent(out)   :: errmsg
-         integer,              intent(out)   :: errflg
+         integer,                           intent(in)    :: nthrds
+         character(len=*),                  intent(out)   :: errmsg
+         integer,                           intent(out)   :: errflg
 
          ! Local variables
          integer :: i, j, ix, vegtyp
@@ -724,49 +730,49 @@
          implicit none
 
          ! Interface variables
-         integer,              intent(in)    :: me, master, cnx, cny, isc, jsc, nrcm, im, levs, kdt, &
-                                                nsswr, imfdeepcnv, iccn, nscyc, ntoz, iflip
-         integer,              intent(in)    :: idate(:)
-         real(kind_phys),      intent(in)    :: fhswr, fhour
-         logical,              intent(in)    :: lsswr, cal_pre, random_clds, h2o_phys, iaerclm
-         real(kind_phys),      intent(out)   :: clstp
-         integer,              intent(in)    :: jindx1_o3(:), jindx2_o3(:), jindx1_h(:), jindx2_h(:)
-         real(kind_phys),      intent(in)    :: ddy_o3(:),  ddy_h(:)
-         real(kind_phys),      intent(inout) :: ozpl(:,:,:), h2opl(:,:,:)
-         integer,              intent(in)    :: jindx1_aer(:), jindx2_aer(:), iindx1_aer(:), iindx2_aer(:)
-         real(kind_phys),      intent(in)    :: ddy_aer(:), ddx_aer(:)
-         real(kind_phys),      intent(inout) :: aer_nm(:,:,:)
-         integer,              intent(in)    :: jindx1_ci(:), jindx2_ci(:), iindx1_ci(:), iindx2_ci(:)
-         real(kind_phys),      intent(in)    :: ddy_ci(:), ddx_ci(:)
-         real(kind_phys),      intent(inout) :: in_nm(:,:), ccn_nm(:,:)
-         integer,              intent(in)    :: imap(:), jmap(:)
-         real(kind_phys),      intent(in)    :: prsl(:,:)
-         integer,              intent(in)    :: seed0
-         real(kind_phys),      intent(inout) :: rann(:,:)
+         integer,                           intent(in)    :: me, master, cnx, cny, isc, jsc, nrcm, im, levs, kdt, &
+                                                             nsswr, imfdeepcnv, iccn, nscyc, ntoz, iflip
+         integer,                           intent(in)    :: idate(:)
+         real(kind_phys),                   intent(in)    :: fhswr, fhour
+         logical,                           intent(in)    :: lsswr, cal_pre, random_clds, h2o_phys, iaerclm
+         real(kind_phys),                   intent(out)   :: clstp
+         integer,              allocatable, intent(in)    :: jindx1_o3(:), jindx2_o3(:), jindx1_h(:), jindx2_h(:)
+         real(kind_phys),      allocatable, intent(in)    :: ddy_o3(:),  ddy_h(:)
+         real(kind_phys),      allocatable, intent(inout) :: ozpl(:,:,:), h2opl(:,:,:)
+         integer,              allocatable, intent(in)    :: jindx1_aer(:), jindx2_aer(:), iindx1_aer(:), iindx2_aer(:)
+         real(kind_phys),      allocatable, intent(in)    :: ddy_aer(:), ddx_aer(:)
+         real(kind_phys),      allocatable, intent(inout) :: aer_nm(:,:,:)
+         integer,              allocatable, intent(in)    :: jindx1_ci(:), jindx2_ci(:), iindx1_ci(:), iindx2_ci(:)
+         real(kind_phys),      allocatable, intent(in)    :: ddy_ci(:), ddx_ci(:)
+         real(kind_phys),      allocatable, intent(inout) :: in_nm(:,:), ccn_nm(:,:)
+         integer,              allocatable, intent(in)    :: imap(:), jmap(:)
+         real(kind_phys),      allocatable, intent(in)    :: prsl(:,:)
+         integer,                           intent(in)    :: seed0
+         real(kind_phys),      allocatable, intent(inout) :: rann(:,:)
 
-         logical,              intent(in)    :: do_ugwp_v1
-         integer,              intent(in)    :: jindx1_tau(:), jindx2_tau(:)
-         real(kind_phys),      intent(in)    :: ddy_j1tau(:), ddy_j2tau(:)
-         real(kind_phys),      intent(inout) :: tau_amf(:)
+         logical,                           intent(in)    :: do_ugwp_v1
+         integer,              allocatable, intent(in)    :: jindx1_tau(:), jindx2_tau(:)
+         real(kind_phys),      allocatable, intent(in)    :: ddy_j1tau(:), ddy_j2tau(:)
+         real(kind_phys),      allocatable, intent(inout) :: tau_amf(:)
 
          ! For gcycle only
-         integer,              intent(in)    :: nthrds, nx, ny, nsst, tile_num, nlunit, lsoil
-         integer,              intent(in)    :: lsoil_lsm, kice, ialb, isot, ivegsrc
-         character(len=*),     intent(in)    :: input_nml_file(:)
-         logical,              intent(in)    :: use_ufo, nst_anl, frac_grid
-         real(kind_phys),      intent(in)    :: fhcyc, phour, lakefrac(:), min_seaice, min_lakeice,  &
-                                                xlat_d(:), xlon_d(:), landfrac(:)
-         real(kind_phys),      intent(inout) :: smc(:,:), slc(:,:), stc(:,:), smois(:,:), sh2o(:,:), &
-                                      tslb(:,:), tiice(:,:), tg3(:), tref(:),                        &
-                                      tsfc(:), tsfco(:), tisfc(:), hice(:), fice(:),                 &
-                                      facsf(:), facwf(:), alvsf(:), alvwf(:), alnsf(:), alnwf(:),    &
-                                      zorli(:), zorll(:), zorlo(:), weasd(:), snoalb(:),             &
-                                      canopy(:), vfrac(:), shdmin(:), shdmax(:),                     &
-                                      snowd(:), cv(:), cvb(:), cvt(:), oro(:), oro_uf(:), slmsk(:)
-         integer,              intent(inout) :: vtype(:), stype(:), slope(:)
+         integer,                           intent(in)    :: nthrds, nx, ny, nsst, tile_num, nlunit, lsoil
+         integer,                           intent(in)    :: lsoil_lsm, kice, ialb, isot, ivegsrc
+         character(len=*),                  intent(in)    :: input_nml_file(:)
+         logical,                           intent(in)    :: use_ufo, nst_anl, frac_grid
+         real(kind_phys),                   intent(in)    :: fhcyc, phour, min_seaice, min_lakeice
+         real(kind_phys),      allocatable, intent(in)    :: lakefrac(:), xlat_d(:), xlon_d(:), landfrac(:)
+         real(kind_phys),      allocatable, intent(inout) :: smc(:,:), slc(:,:), stc(:,:), smois(:,:), sh2o(:,:), &
+                                                             tslb(:,:), tiice(:,:), tg3(:), tref(:),                        &
+                                                             tsfc(:), tsfco(:), tisfc(:), hice(:), fice(:),                 &
+                                                             facsf(:), facwf(:), alvsf(:), alvwf(:), alnsf(:), alnwf(:),    &
+                                                             zorli(:), zorll(:), zorlo(:), weasd(:), snoalb(:),             &
+                                                             canopy(:), vfrac(:), shdmin(:), shdmax(:),                     &
+                                                             snowd(:), cv(:), cvb(:), cvt(:), oro(:), oro_uf(:), slmsk(:)
+         integer,              allocatable, intent(inout) :: vtype(:), stype(:), slope(:)
 
-         character(len=*),     intent(out)   :: errmsg
-         integer,              intent(out)   :: errflg
+         character(len=*),                  intent(out)   :: errmsg
+         integer,                           intent(out)   :: errflg
 
          ! Local variables
          integer :: i, j, k, iseed, iskip, ix

--- a/physics/GFS_rad_time_vary.fv3.F90
+++ b/physics/GFS_rad_time_vary.fv3.F90
@@ -29,23 +29,23 @@
          implicit none
 
          ! Interface variables
-         logical,                intent(in)    :: lrseeds
-         integer,                intent(in)    :: rseeds(:,:)
-         integer,                intent(in)    :: isubc_lw, isubc_sw, cnx, cny, isc, jsc, kdt
-         integer,                intent(in)    :: imp_physics, imp_physics_zhao_carr
-         logical,                intent(in)    :: lslwr, lsswr
-         integer,                intent(inout) :: icsdsw(:), icsdlw(:)
-         integer,                intent(in)    :: imap(:), jmap(:)
-         real(kind_phys),        intent(in)    :: sec
-         real(kind_phys),        intent(inout) :: ps_2delt(:)
-         real(kind_phys),        intent(inout) :: ps_1delt(:)
-         real(kind_phys),        intent(inout) :: t_2delt(:,:)
-         real(kind_phys),        intent(inout) :: t_1delt(:,:)
-         real(kind_phys),        intent(inout) :: qv_2delt(:,:)
-         real(kind_phys),        intent(inout) :: qv_1delt(:,:)
-         real(kind_phys),        intent(in)    :: t(:,:), qv(:,:), ps(:)
-         character(len=*),       intent(out)   :: errmsg
-         integer,                intent(out)   :: errflg
+         logical,                             intent(in)    :: lrseeds
+         integer,                allocatable, intent(in)    :: rseeds(:,:)
+         integer,                             intent(in)    :: isubc_lw, isubc_sw, cnx, cny, isc, jsc, kdt
+         integer,                             intent(in)    :: imp_physics, imp_physics_zhao_carr
+         logical,                             intent(in)    :: lslwr, lsswr
+         integer,                allocatable, intent(inout) :: icsdsw(:), icsdlw(:)
+         integer,                allocatable, intent(in)    :: imap(:), jmap(:)
+         real(kind_phys),                     intent(in)    :: sec
+         real(kind_phys),        allocatable, intent(inout) :: ps_2delt(:)
+         real(kind_phys),        allocatable, intent(inout) :: ps_1delt(:)
+         real(kind_phys),        allocatable, intent(inout) :: t_2delt(:,:)
+         real(kind_phys),        allocatable, intent(inout) :: t_1delt(:,:)
+         real(kind_phys),        allocatable, intent(inout) :: qv_2delt(:,:)
+         real(kind_phys),        allocatable, intent(inout) :: qv_1delt(:,:)
+         real(kind_phys),        allocatable, intent(in)    :: t(:,:), qv(:,:), ps(:)
+         character(len=*),                    intent(out)   :: errmsg
+         integer,                             intent(out)   :: errflg
 
          ! Local variables
          type (random_stat) :: stat

--- a/physics/GFS_radiation_surface.F90
+++ b/physics/GFS_radiation_surface.F90
@@ -74,15 +74,16 @@
       logical, dimension(:), intent(in) :: use_flake
 
       real(kind=kind_phys), dimension(:),   intent(in)  :: xlat, xlon, slmsk,           &
-                                                           sfc_alb_pert, lndp_prt_list, &
+                                                           sfc_alb_pert,                &
                                                            landfrac, lakefrac,          &
                                                            snodl, snodi, sncovr,        &
                                                            sncovr_ice, fice, zorl,      &
                                                            hprime, tsfg, tsfa, tisfc,   &
                                                            coszen, alvsf, alnsf, alvwf, &
                                                            alnwf, facsf, facwf, snoalb
-      character(len=3)    , dimension(:),   intent(in)  :: lndp_var_list
-      real(kind=kind_phys), dimension(:),   intent(in)  :: albdvis_ice, albdnir_ice,    &
+      real(kind=kind_phys), dimension(:),   pointer     :: lndp_prt_list
+      character(len=3)    , dimension(:),   pointer     :: lndp_var_list
+      real(kind=kind_phys), dimension(:),   pointer     :: albdvis_ice, albdnir_ice,    &
                                                            albivis_ice, albinir_ice
 
       real(kind=kind_phys), dimension(:),   intent(inout) :: albdvis_lnd, albdnir_lnd,  &

--- a/physics/GFS_rrtmg_pre.F90
+++ b/physics/GFS_rrtmg_pre.F90
@@ -119,17 +119,17 @@
       integer, intent(in) :: ntdu1, ntdu2, ntdu3, ntdu4, ntdu5, ntss1, ntss2, ntss3,  &
                              ntss4, ntss5, ntsu, ntbcb, ntbcl, ntocb, ntocl, ntchm
 
-      character(len=3), dimension(:), intent(in) :: lndp_var_list
+      character(len=3), dimension(:), pointer    :: lndp_var_list
 
       logical,              intent(in) :: lextop, lsswr, lslwr, ltaerosol, lgfdlmprad, &
                                           uni_cld, effr_in, do_mynnedmf,       &
                                           lmfshal, lmfdeep2, pert_clds, mraerosol
       logical,              intent(in) :: aero_dir_fdb
-      real(kind=kind_phys), dimension(:,:), intent(in) :: smoke_ext, dust_ext
+      real(kind=kind_phys), dimension(:,:), pointer    :: smoke_ext, dust_ext
 
       logical,              intent(in) :: nssl_ccn_on, nssl_invertccn
       integer,              intent(in) :: spp_rad
-      real(kind_phys),      intent(in) :: spp_wts_rad(:,:)
+      real(kind_phys),      pointer    :: spp_wts_rad(:,:)
 
       real(kind=kind_phys), intent(in) :: fhswr, fhlwr, solhr, sup, julian, sppt_amp
       real(kind=kind_phys), intent(in) :: con_eps, epsm1, fvirt, rog, rocp, con_rd
@@ -139,10 +139,10 @@
                                                         slmsk, dx
 
       real(kind=kind_phys), dimension(:,:), intent(in) :: prsi, prsl, prslk,   &
-                                                          tgrs, sfc_wts,       &
+                                                          tgrs,                &
                                                           mg_cld, effrr_in,    &
-                                                          cnvw_in, cnvc_in,    &
-                                                          sppt_wts
+                                                          cnvw_in, cnvc_in
+      real(kind=kind_phys), dimension(:,:), pointer    :: sfc_wts, sppt_wts
 
       real(kind=kind_phys), dimension(:,:,:), intent(in) :: qgrs
       real(kind=kind_phys), dimension(:,:,:), intent(inout) :: aer_nm
@@ -155,7 +155,7 @@
       real(kind=kind_phys), dimension(:,:), intent(inout) :: clouds1,          &
                                                              clouds2, clouds3, &
                                                              clouds4, clouds5
-      real(kind=kind_phys), dimension(:,:), intent(in)  :: qci_conv
+      real(kind=kind_phys), dimension(:,:), pointer     :: qci_conv
       real(kind=kind_phys), dimension(:),   intent(out) :: lwp_ex,iwp_ex, &
                                                            lwp_fc,iwp_fc
 

--- a/physics/GFS_suite_interstitial_2.F90
+++ b/physics/GFS_suite_interstitial_2.F90
@@ -30,9 +30,10 @@
       logical,              intent(in   ), dimension(:)     :: flag_cice
       real(kind=kind_phys), intent(in   ), dimension(:)     :: ctei_rm
       real(kind=kind_phys), intent(in   ), dimension(:)     :: xcosz, adjsfcdsw, adjsfcdlw, pgr, xmu, work1, work2
-      real(kind=kind_phys), intent(in   ), dimension(:)     :: ulwsfc_cice
+      real(kind=kind_phys), pointer      , dimension(:)     :: ulwsfc_cice
       real(kind=kind_phys), intent(in   ), dimension(:)     :: cice
-      real(kind=kind_phys), intent(in   ), dimension(:,:)   :: htrsw, htrlw, htrlwu, tgrs, prsl, qgrs_water_vapor, qgrs_cloud_water, prslk
+      real(kind=kind_phys), pointer      , dimension(:,:)   :: htrlwu
+      real(kind=kind_phys), intent(in   ), dimension(:,:)   :: htrsw, htrlw, tgrs, prsl, qgrs_water_vapor, qgrs_cloud_water, prslk
       real(kind=kind_phys), intent(in   ), dimension(:,:)   :: prsi
       real(kind=kind_phys), intent(in   ), dimension(:,:,:) :: lwhd
       integer,              intent(inout), dimension(:)     :: kinver

--- a/physics/GFS_suite_interstitial_3.F90
+++ b/physics/GFS_suite_interstitial_3.F90
@@ -53,7 +53,8 @@
       real(kind=kind_phys), intent(in   ), dimension(:,:,:) :: gq0
 
       real(kind=kind_phys), intent(inout   ), dimension(:,:)   :: sigmain
-      real(kind=kind_phys), intent(inout   ), dimension(:,:)   :: sigmaout,qmicro
+      real(kind=kind_phys), intent(inout   ), dimension(:,:)   :: sigmaout
+      real(kind=kind_phys), pointer         , dimension(:,:)   :: qmicro
       real(kind=kind_phys), intent(inout), dimension(:,:)   :: rhc, save_qc
       ! save_qi is not allocated for Zhao-Carr MP
       real(kind=kind_phys), intent(inout), dimension(:,:)   :: save_qi

--- a/physics/GFS_suite_interstitial_4.F90
+++ b/physics/GFS_suite_interstitial_4.F90
@@ -37,7 +37,7 @@
 
       ! dtend and dtidx are only allocated if ldiag3d
       logical, intent(in)                                   :: ldiag3d, qdiag3d
-      real(kind=kind_phys), dimension(:,:,:), intent(inout) :: dtend
+      real(kind=kind_phys), dimension(:,:,:), pointer       :: dtend
       integer,              dimension(:,:),   intent(in)    :: dtidx
       integer,                                intent(in)    :: index_of_process_conv_trans,ntk,ntke
 

--- a/physics/GFS_surface_generic_post.F90
+++ b/physics/GFS_surface_generic_post.F90
@@ -65,14 +65,15 @@
 
         real(kind=kind_phys), dimension(:),  intent(in)  :: ep1d, gflx, tgrs_1, qgrs_1, ugrs_1, vgrs_1, adjsfcdlw, adjsfcdsw,  &
           adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfculw, adjsfculw_wat, adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,    &
-          t2m, q2m, u10m, v10m, tsfc, tsfc_wat, pgr, xcosz, evbs, evcw, trans, sbsno, snowc, snohf, pah, ecan, etran, edir,    &
-          waxy
+          t2m, q2m, u10m, v10m, tsfc, tsfc_wat, pgr, xcosz, evbs, evcw, trans, sbsno, snowc, snohf, pah, ecan, etran, edir
 
-        real(kind=kind_phys), dimension(:),  intent(inout) :: epi, gfluxi, t1, q1, u1, v1, dlwsfci_cpl, dswsfci_cpl, dlwsfc_cpl, &
+        real(kind=kind_phys), dimension(:),  intent(inout) :: epi, gfluxi, t1, q1, u1, v1, gflux, evbsa, evcwa, transa, sbsnoa,&
+          snowca, snohfa, ep, tecan, tetran, tedir
+
+        real(kind=kind_phys), dimension(:),  pointer       :: dlwsfci_cpl, dswsfci_cpl, dlwsfc_cpl, &
           dswsfc_cpl, dnirbmi_cpl, dnirdfi_cpl, dvisbmi_cpl, dvisdfi_cpl, dnirbm_cpl, dnirdf_cpl, dvisbm_cpl, dvisdf_cpl,        &
           nlwsfci_cpl, nlwsfc_cpl, t2mi_cpl, q2mi_cpl, u10mi_cpl, v10mi_cpl, tsfci_cpl, psurfi_cpl, nnirbmi_cpl, nnirdfi_cpl,    &
-          nvisbmi_cpl, nvisdfi_cpl, nswsfci_cpl, nswsfc_cpl, nnirbm_cpl, nnirdf_cpl, nvisbm_cpl, nvisdf_cpl, gflux, evbsa,       &
-          evcwa, transa, sbsnoa, snowca, snohfa, ep, paha, tecan, tetran, tedir, twa, pahi
+          nvisbmi_cpl, nvisdfi_cpl, nswsfci_cpl, nswsfc_cpl, nnirbm_cpl, nnirdf_cpl, nvisbm_cpl, nvisdf_cpl, pahi, paha, twa, waxy
 
         real(kind=kind_phys), dimension(:), intent(inout) :: runoff, srunoff
         real(kind=kind_phys), dimension(:), intent(in)    :: drain, runof

--- a/physics/GFS_surface_generic_pre.F90
+++ b/physics/GFS_surface_generic_pre.F90
@@ -91,9 +91,9 @@
         real(kind=kind_phys), dimension(:),   intent(in)  :: rain_cpl
         real(kind=kind_phys), dimension(:),   intent(in)  :: snow_cpl
         integer,                              intent(in)  :: lndp_type, n_var_lndp
-        character(len=3),     dimension(:),   intent(in)  :: lndp_var_list
-        real(kind=kind_phys), dimension(:),   intent(in)  :: lndp_prt_list
-        real(kind=kind_phys), dimension(:,:), intent(in)  :: sfc_wts
+        character(len=3),     dimension(:),   pointer     :: lndp_var_list
+        real(kind=kind_phys), dimension(:),   pointer     :: lndp_prt_list
+        real(kind=kind_phys), dimension(:,:), pointer     :: sfc_wts
         real(kind=kind_phys), dimension(:),   intent(out) :: z01d
         real(kind=kind_phys), dimension(:),   intent(out) :: zt1d
         real(kind=kind_phys), dimension(:),   intent(out) :: bexp1d
@@ -102,7 +102,7 @@
         real(kind=kind_phys),                 intent(out) :: lndp_vgf
 
         logical,                              intent(in)    :: cplflx
-        real(kind=kind_phys), dimension(:),   intent(in)    :: slimskin_cpl
+        real(kind=kind_phys), dimension(:),   pointer       :: slimskin_cpl
         logical,              dimension(:),   intent(inout) :: flag_cice
         integer,              dimension(:),   intent(out)   :: islmsk_cice
 

--- a/physics/cires_ugwp.F90
+++ b/physics/cires_ugwp.F90
@@ -230,12 +230,12 @@ contains
     real(kind=kind_phys),    intent(out), dimension(:)      :: tau_mtb, tau_ogw, tau_tofd, tau_ngw
     real(kind=kind_phys),    intent(out), dimension(:, :):: gw_dudt, gw_dvdt, gw_dtdt, gw_kdis
     real(kind=kind_phys),    intent(out), dimension(:, :):: dudt_mtb, dudt_ogw, dudt_tms
-    real(kind=kind_phys),    intent(out), dimension(:)    :: dusfc_ms, dvsfc_ms, dusfc_bl, dvsfc_bl
-    real(kind=kind_phys),    intent(out), dimension(:, :) :: dtauy2d_ms
-    real(kind=kind_phys),    intent(out), dimension(:, :) :: dtaux2d_bl, dtauy2d_bl
+    real(kind=kind_phys),    pointer    , dimension(:)    :: dusfc_ms, dvsfc_ms, dusfc_bl, dvsfc_bl
+    real(kind=kind_phys),    pointer    , dimension(:, :) :: dtauy2d_ms
+    real(kind=kind_phys),    pointer    , dimension(:, :) :: dtaux2d_bl, dtauy2d_bl
 
     ! dtend is only allocated if ldiag=.true.
-    real(kind=kind_phys), optional, intent(inout)            :: dtend(:,:,:)
+    real(kind=kind_phys), optional, pointer                  :: dtend(:,:,:)
     integer, intent(in)                                      :: dtidx(:,:), &
          index_of_x_wind, index_of_y_wind, index_of_temperature,         &
          index_of_process_orographic_gwd, index_of_process_nonorographic_gwd
@@ -243,7 +243,7 @@ contains
     logical,                 intent(in)                         :: ldiag3d, lssav
 
     ! These arrays only allocated if ldiag_ugwp = .true.
-    real(kind=kind_phys),    intent(inout), dimension(:,:) :: du3dt_mtb, du3dt_ogw, du3dt_tms
+    real(kind=kind_phys),    pointer      , dimension(:,:) :: du3dt_mtb, du3dt_ogw, du3dt_tms
 
     real(kind=kind_phys),    intent(inout), dimension(:, :):: dudt, dvdt, dtdt
 

--- a/physics/cires_ugwp_post.F90
+++ b/physics/cires_ugwp_post.F90
@@ -34,7 +34,7 @@ contains
         real(kind=kind_phys), intent(inout), dimension(:)   :: tot_mtb, tot_ogw, tot_tofd, tot_ngw
         real(kind=kind_phys), intent(inout), dimension(:)   :: tot_zmtb, tot_zlwb, tot_zogw
         real(kind=kind_phys), intent(in),    dimension(:,:) :: gw_dtdt, gw_dudt, gw_dvdt, dudt_mtb, dudt_ogw, dudt_tms
-        real(kind=kind_phys), intent(inout), dimension(:,:) :: du3dt_mtb, du3dt_ogw, du3dt_tms, du3dt_ngw, dv3dt_ngw
+        real(kind=kind_phys), pointer      , dimension(:,:) :: du3dt_mtb, du3dt_ogw, du3dt_tms, du3dt_ngw, dv3dt_ngw
         real(kind=kind_phys), intent(inout), dimension(:,:) :: dtdt, dudt, dvdt
 
         character(len=*),        intent(out) :: errmsg

--- a/physics/dcyc2t3.f
+++ b/physics/dcyc2t3.f
@@ -214,7 +214,9 @@
 
       real(kind=kind_phys), dimension(:), intent(in) ::                 &
      &      sinlat, coslat, xlon, coszen, tf, tsflw, sfcdlw,            &
-     &      sfcdsw, sfcnsw, sfculw, sfculw_med, tsfc, tsfc_radtime
+     &      sfcdsw, sfcnsw, sfculw, tsfc
+      real(kind=kind_phys), dimension(:), pointer    ::                 &
+     &      sfculw_med, tsfc_radtime
 
       real(kind=kind_phys), dimension(:), intent(in) ::                 &
      &                         tsfc_lnd, tsfc_ice, tsfc_wat,            &
@@ -227,7 +229,9 @@
       real(kind=kind_phys), dimension(:,:), intent(in) :: swh, hlw,     &
      &                                     swhc, hlwc, p_lay, t_lay
 
-      real(kind=kind_phys), dimension(:,:), intent(in) :: p_lev,        &
+      real(kind=kind_phys), dimension(:,:), intent(in) :: p_lev
+
+      real(kind=kind_phys), dimension(:,:), pointer    ::               &
      &     flux2D_lwUP, flux2D_lwDOWN, fluxlwUP_jac
 
       real(kind_phys),           intent(in   ) :: con_g, con_cp,        &
@@ -237,8 +241,9 @@
 
 
 !  ---  input/output:
-      real(kind=kind_phys), dimension(:,:), intent(inout) :: dtdt, htrlw
-      real(kind=kind_phys), dimension(:,:), intent(inout) :: dtdtnp
+      real(kind=kind_phys), dimension(:,:), intent(inout) :: dtdt
+      real(kind=kind_phys), dimension(:,:), pointer       :: htrlw
+      real(kind=kind_phys), dimension(:,:), pointer       :: dtdtnp
 
 !  ---  outputs:
       real(kind=kind_phys), dimension(:), intent(out) ::                &

--- a/physics/gfdl_cloud_microphys.F90
+++ b/physics/gfdl_cloud_microphys.F90
@@ -160,7 +160,7 @@ contains
       real(kind=kind_phys), intent(inout), dimension(:,:) :: rew, rei, rer, res, reg
       logical, intent (in) :: cplchm
       ! ice and liquid water 3d precipitation fluxes - only allocated if cplchm is .true.
-      real(kind=kind_phys), intent(inout), dimension(:,:) :: pfi_lsan, pfl_lsan
+      real(kind=kind_phys), pointer      , dimension(:,:) :: pfi_lsan, pfl_lsan
 
       character(len=*), intent(out) :: errmsg
       integer, intent(out)          :: errflg

--- a/physics/gwdps.f
+++ b/physics/gwdps.f
@@ -315,10 +315,11 @@
      &                     THETA(:), SIGMA(:), GAMMA(:)
       real(kind=kind_phys), intent(inout) :: DUSFC(:), DVSFC(:),        &
      &                     RDXZB(:)
-      real(kind=kind_phys), intent(inout) :: dtaux2d_ms(:,:),           &
+      real(kind=kind_phys), intent(inout) :: dtaux2d_ms(:,:)
+      real(kind=kind_phys), pointer       ::                            &
      &                     dtauy2d_ms(:,:), dtaux2d_bl(:,:),            &
      &                     dtauy2d_bl(:,:)
-      real(kind=kind_phys), intent(inout) :: dusfc_ms(:), dvsfc_ms(:),  &
+      real(kind=kind_phys), pointer       :: dusfc_ms(:), dvsfc_ms(:),  &
      &                     dusfc_bl(:), dvsfc_bl(:)
       integer, intent(in) :: nmtvr
       logical, intent(in) :: lprnt

--- a/physics/ozphys_2015.f
+++ b/physics/ozphys_2015.f
@@ -62,7 +62,7 @@
      &                                    prsl(:,:), tin(:,:),          &
      &                                    delp(:,:),                    &
      &                                    prdout(:,:,:), dt
-      real(kind=kind_phys), intent(inout) :: dtend(:,:,:)
+      real(kind=kind_phys), pointer       :: dtend(:,:,:)
       integer, intent(in) :: dtidx(:,:), ntoz,                          &
      &  index_of_process_prod_loss, index_of_process_ozmix,             &
      &  index_of_process_temp, index_of_process_overhead_ozone

--- a/physics/radiation_surface.f
+++ b/physics/radiation_surface.f
@@ -417,8 +417,9 @@
      &       lakefrac,                                                  &
      &       slmsk, snodi, zorlf, coszf, tsknf, tairf, hprif,           &
      &       alvsf, alnsf, alvwf, alnwf, facsf, facwf, fice, tisfc,     &
-     &       icealbdvis, icealbdnir, icealbivis, icealbinir,            &
      &       sncovr, sncovr_ice, snoalb, albPpert           ! sfc-perts, mgehne
+      real (kind=kind_phys), dimension(:), pointer ::                   &
+     &       icealbdvis, icealbdnir, icealbivis, icealbinir
       real (kind=kind_phys),  intent(in) :: pertalb         ! sfc-perts, mgehne
       real (kind=kind_phys), dimension(:), intent(in) ::                &
      &       fracl, fraco, fraci

--- a/physics/samfdeepcnv.f
+++ b/physics/samfdeepcnv.f
@@ -100,9 +100,10 @@
       logical, intent(in)  :: first_time_step,restart,hwrf_samfdeep,    &
      &     progsigma
       real(kind=kind_phys), intent(in) :: nthresh
-      real(kind=kind_phys), intent(in) :: ca_deep(:)
-      real(kind=kind_phys), intent(in) :: sigmain(:,:),qmicro(:,:),     &
-     &     tmf(:,:),q(:,:), prevsq(:,:)
+      real(kind=kind_phys), pointer    :: ca_deep(:)
+      real(kind=kind_phys), intent(in) :: sigmain(:,:),                 &
+     &     q(:,:), prevsq(:,:)
+      real(kind=kind_phys), pointer    :: qmicro(:,:), tmf(:,:)
       real(kind=kind_phys), intent(out) :: rainevap(:)
       real(kind=kind_phys), intent(out) :: sigmaout(:,:)
       logical, intent(in)  :: do_ca,ca_closure,ca_entr,ca_trigger
@@ -121,7 +122,7 @@
       ! GJF* These variables are conditionally allocated depending on whether the
       !     Morrison-Gettelman microphysics is used, so they must be declared 
       !     using assumed shape.
-      real(kind=kind_phys), dimension(:,:), intent(inout) ::            &
+      real(kind=kind_phys), dimension(:,:), pointer ::                  &
      &   qlcn, qicn, w_upi, cnv_mfd, cnv_dqldt, clcn                    &
      &,  cnv_fice, cnv_ndrop, cnv_nice, cf_upi
       ! *GJF

--- a/physics/samfshalcnv.f
+++ b/physics/samfshalcnv.f
@@ -70,7 +70,8 @@
       real(kind=kind_phys), intent(in) ::  delt
       real(kind=kind_phys), intent(in) :: psp(:), delp(:,:),            &
      &   prslp(:,:), garea(:), hpbl(:), dot(:,:), phil(:,:),            &
-     &   qmicro(:,:),tmf(:,:),prevsq(:,:),q(:,:)
+     &   prevsq(:,:),q(:,:)
+      real(kind=kind_phys), pointer    :: qmicro(:,:),tmf(:,:)
 
       real(kind=kind_phys), intent(in) :: sigmain(:,:)
 !

--- a/physics/satmedmfvdifq.F
+++ b/physics/satmedmfvdifq.F
@@ -106,7 +106,8 @@
       real(kind=kind_phys), intent(in) :: dspfac, bl_upfr, bl_dnfr
       real(kind=kind_phys), intent(in) :: rlmx, elmx
       real(kind=kind_phys), intent(inout) :: dv(:,:),     du(:,:),      &
-     &                     tdt(:,:),    rtg(:,:,:), tmf(:,:)
+     &                     tdt(:,:),    rtg(:,:,:)
+      real(kind=kind_phys), pointer       :: tmf(:,:)
       real(kind=kind_phys), intent(in) ::                               &
      &                     u1(:,:),     v1(:,:),                        &
      &                     t1(:,:),     q1(:,:,:),                      &
@@ -122,7 +123,7 @@
      &                     prsi(:,:), del(:,:),                         &
      &                     prsl(:,:),   prslk(:,:),                     &
      &                     phii(:,:), phil(:,:)
-      real(kind=kind_phys), intent(inout), dimension(:,:,:) :: dtend
+      real(kind=kind_phys), pointer      , dimension(:,:,:) :: dtend
       integer, intent(in) :: dtidx(:,:), index_of_temperature,          &
      &       index_of_x_wind, index_of_y_wind, index_of_process_pbl
       real(kind=kind_phys), intent(out) ::                              &

--- a/physics/sfc_diag_post.F90
+++ b/physics/sfc_diag_post.F90
@@ -27,7 +27,7 @@
         logical             , dimension(:),  intent(in) :: dry
         real(kind=kind_phys), dimension(:),  intent(in) :: pgr, u10m, v10m
         real(kind=kind_phys), dimension(:),  intent(inout) :: t2m, q2m, tmpmin, tmpmax, spfhmin, spfhmax
-        real(kind=kind_phys), dimension(:),  intent(inout) :: t2mmp, q2mp
+        real(kind=kind_phys), dimension(:),  pointer       :: t2mmp, q2mp
         real(kind=kind_phys), dimension(:),  intent(inout) :: wind10mmax, u10mmax, v10mmax, dpt2m
 
         character(len=*),                     intent(out) :: errmsg


### PR DESCRIPTION
This PR includes changes to allow AQMv7 to run on WCOSS2 after the code is built using the `-check all` compiler flag.

This is a requirement for the operational implementation of AQMv7. 

**NOTE:** The proposed changes are limited to the AQMv7 operational configuration. Additional changes may be required for full compliance