### PR TITLE
fix crash when using clm lake and GFS PBL/sfclay

### DIFF
--- a/physics/GFS_surface_composites_pre.F90
+++ b/physics/GFS_surface_composites_pre.F90
@@ -241,8 +241,10 @@ contains
         !mjz
           tsfcl(i) = huge
         endif
+        if (icy(i) .or. wet(i)) then ! init uustar_ice for all water/ice grids 
+           uustar_ice(i) = uustar(i)
+        endif
         if (icy(i)) then                   ! Ice
-          uustar_ice(i) = uustar(i)
           is_clm = lkm>0 .and. iopt_lake==iopt_lake_clm .and. use_lake_model(i)>0
           if(lsm /= lsm_ruc .and. .not.is_clm) then
             weasd_ice(i) = weasd(i)

--- a/physics/clm_lake.f90
+++ b/physics/clm_lake.f90
@@ -757,7 +757,7 @@ MODULE clm_lake
                   snowd(i)      = snodi(c)                  ! surface_snow_thickness_water_equivalent_over_ice
 
 
-                  if (icy(i) .eq. .false.) then
+                  if (.not. icy(i)) then
                      lake_freeze(i)=.true.
                   end if
 

--- a/physics/clm_lake.f90
+++ b/physics/clm_lake.f90
@@ -268,7 +268,7 @@ MODULE clm_lake
          ! Atmospheric model state inputs:
          tg3, pgr, zlvl, gt0, prsi, phii, qvcurr, gu0, gv0, xlat_d, xlon_d,       &
          ch, cm, dlwsfci, dswsfci, oro_lakedepth, wind, rho0, tsfc,               &
-         flag_iter, ISLTYP, rainncprv, raincprv,                                  &
+         flag_iter, lake_freeze, ISLTYP, rainncprv, raincprv,                     &
 
          ! Feedback to atmosphere:
          evap_wat,     evap_ice,   hflx_wat,    hflx_ice,  gflx_wat, gflx_ice,    &
@@ -325,6 +325,8 @@ MODULE clm_lake
          rainncprv, raincprv
     REAL(KIND_PHYS), DIMENSION(:,:), INTENT(in) :: gu0, gv0, prsi, gt0, phii
     LOGICAL, DIMENSION(:), INTENT(IN) :: flag_iter
+    LOGICAL, DIMENSION(:), INTENT(INOUT) :: lake_freeze
+
     INTEGER, DIMENSION(:), INTENT(IN) :: ISLTYP
 
     !
@@ -753,6 +755,11 @@ MODULE clm_lake
                   snodi(i)      = snowdp(c)*1.e3            ! surface_snow_thickness_water_equivalent_over_ice
                   weasd(i)      = weasdi(i)
                   snowd(i)      = snodi(c)                  ! surface_snow_thickness_water_equivalent_over_ice
+
+
+                  if (icy(i) .eq. .false.) then
+                     lake_freeze(i)=.true.
+                  end if
 
                   ! Ice points are icy:
                   icy(i)=.true.                             ! flag_nonzero_sea_ice_surface_fraction

--- a/physics/clm_lake.f90
+++ b/physics/clm_lake.f90
@@ -268,7 +268,7 @@ MODULE clm_lake
          ! Atmospheric model state inputs:
          tg3, pgr, zlvl, gt0, prsi, phii, qvcurr, gu0, gv0, xlat_d, xlon_d,       &
          ch, cm, dlwsfci, dswsfci, oro_lakedepth, wind, rho0, tsfc,               &
-         flag_iter, flag_lakefreeze, ISLTYP, rainncprv, raincprv,                     &
+         flag_iter, flag_lakefreeze, ISLTYP, rainncprv, raincprv,                 &
 
          ! Feedback to atmosphere:
          evap_wat,     evap_ice,   hflx_wat,    hflx_ice,  gflx_wat, gflx_ice,    &

--- a/physics/clm_lake.f90
+++ b/physics/clm_lake.f90
@@ -268,7 +268,7 @@ MODULE clm_lake
          ! Atmospheric model state inputs:
          tg3, pgr, zlvl, gt0, prsi, phii, qvcurr, gu0, gv0, xlat_d, xlon_d,       &
          ch, cm, dlwsfci, dswsfci, oro_lakedepth, wind, rho0, tsfc,               &
-         flag_iter, lake_freeze, ISLTYP, rainncprv, raincprv,                     &
+         flag_iter, flag_lakefreeze, ISLTYP, rainncprv, raincprv,                     &
 
          ! Feedback to atmosphere:
          evap_wat,     evap_ice,   hflx_wat,    hflx_ice,  gflx_wat, gflx_ice,    &
@@ -325,7 +325,7 @@ MODULE clm_lake
          rainncprv, raincprv
     REAL(KIND_PHYS), DIMENSION(:,:), INTENT(in) :: gu0, gv0, prsi, gt0, phii
     LOGICAL, DIMENSION(:), INTENT(IN) :: flag_iter
-    LOGICAL, DIMENSION(:), INTENT(INOUT) :: lake_freeze
+    LOGICAL, DIMENSION(:), INTENT(INOUT) :: flag_lakefreeze
 
     INTEGER, DIMENSION(:), INTENT(IN) :: ISLTYP
 
@@ -758,7 +758,7 @@ MODULE clm_lake
 
 
                   if (.not. icy(i)) then
-                     lake_freeze(i)=.true.
+                     flag_lakefreeze(i)=.true.
                   end if
 
                   ! Ice points are icy:

--- a/physics/clm_lake.meta
+++ b/physics/clm_lake.meta
@@ -328,7 +328,7 @@
   dimensions = (horizontal_loop_extent)
   type = logical
   intent = in
-[lake_freeze]
+[flag_lakefreeze]
   standard_name = flag_for_lake_water_freeze
   long_name = flag for lake water freeze
   units = flag

--- a/physics/clm_lake.meta
+++ b/physics/clm_lake.meta
@@ -328,6 +328,13 @@
   dimensions = (horizontal_loop_extent)
   type = logical
   intent = in
+[lake_freeze]
+  standard_name = flag_for_lake_water_freeze
+  long_name = flag for lake water freeze
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = logical
+  intent = inout
 [isltyp]
   standard_name = soil_type_classification
   long_name = soil type at each grid cell

--- a/physics/sfc_diff.f
+++ b/physics/sfc_diff.f
@@ -60,7 +60,7 @@
      &                    sigmaf,vegtype,shdmax,ivegsrc,                &  !intent(in)
      &                    z0pert,ztpert,                                &  ! mg, sfc-perts !intent(in)
      &                    flag_iter,redrag,                             &  !intent(in)
-     &                    lake_freeze,                                  &  !intent(in)             
+     &                    flag_lakefreeze,                              &  !intent(in)             
      &                    u10m,v10m,sfc_z0_type,                        &  !hafs,z0 type !intent(in)
      &                    wet,dry,icy,                                  &  !intent(in)
      &                    thsfc_loc,                                    &  !intent(in)
@@ -91,7 +91,7 @@
 
       logical, intent(in) :: redrag ! reduced drag coeff. flag for high wind over sea (j.han)
       logical, dimension(:), intent(in) :: flag_iter, dry, icy
-      logical, dimension(:), intent(in) :: lake_freeze 
+      logical, dimension(:), intent(in) :: flag_lakefreeze 
       logical, dimension(:), intent(inout) :: wet
 
       logical, intent(in) :: thsfc_loc ! Flag for reference pressure in theta calculation
@@ -170,7 +170,7 @@
 !       write(0,*)'in sfc_diff, sfc_z0_type=',sfc_z0_type
 
       do i=1,im
-        if(flag_iter(i) .or. lake_freeze(i)) then
+        if(flag_iter(i) .or. flag_lakefreeze(i)) then
 
           ! Need to initialize ztmax arrays
           ztmax_lnd(i) = 1. ! log(1) = 0

--- a/physics/sfc_diff.f
+++ b/physics/sfc_diff.f
@@ -170,7 +170,7 @@
 !       write(0,*)'in sfc_diff, sfc_z0_type=',sfc_z0_type
 
       do i=1,im
-        if(flag_iter(i) .or. lake_freeze(i) then
+        if(flag_iter(i) .or. lake_freeze(i)) then
 
           ! Need to initialize ztmax arrays
           ztmax_lnd(i) = 1. ! log(1) = 0

--- a/physics/sfc_diff.f
+++ b/physics/sfc_diff.f
@@ -60,6 +60,7 @@
      &                    sigmaf,vegtype,shdmax,ivegsrc,                &  !intent(in)
      &                    z0pert,ztpert,                                &  ! mg, sfc-perts !intent(in)
      &                    flag_iter,redrag,                             &  !intent(in)
+     &                    lake_freeze,                                  &  !intent(in)             
      &                    u10m,v10m,sfc_z0_type,                        &  !hafs,z0 type !intent(in)
      &                    wet,dry,icy,                                  &  !intent(in)
      &                    thsfc_loc,                                    &  !intent(in)
@@ -90,6 +91,7 @@
 
       logical, intent(in) :: redrag ! reduced drag coeff. flag for high wind over sea (j.han)
       logical, dimension(:), intent(in) :: flag_iter, dry, icy
+      logical, dimension(:), intent(in) :: lake_freeze 
       logical, dimension(:), intent(inout) :: wet
 
       logical, intent(in) :: thsfc_loc ! Flag for reference pressure in theta calculation
@@ -168,7 +170,7 @@
 !       write(0,*)'in sfc_diff, sfc_z0_type=',sfc_z0_type
 
       do i=1,im
-        if(flag_iter(i)) then
+        if(flag_iter(i) .or. lake_freeze(i) then
 
           ! Need to initialize ztmax arrays
           ztmax_lnd(i) = 1. ! log(1) = 0

--- a/physics/sfc_diff.meta
+++ b/physics/sfc_diff.meta
@@ -194,7 +194,7 @@
   dimensions = ()
   type = logical
   intent = in
-[lake_freeze]
+[flag_lakefreeze]
   standard_name = flag_for_lake_water_freeze
   long_name = flag for lake water freeze
   units = flag

--- a/physics/sfc_diff.meta
+++ b/physics/sfc_diff.meta
@@ -194,6 +194,13 @@
   dimensions = ()
   type = logical
   intent = in
+[lake_freeze]
+  standard_name = flag_for_lake_water_freeze
+  long_name = flag for lake water freeze
+  units = flag
+  dimensions = (horizontal_loop_extent)
+  type = logical
+  intent = inout
 [u10m]
   standard_name = x_wind_at_10m
   long_name = 10 meter u wind speed

--- a/physics/sfc_diff.meta
+++ b/physics/sfc_diff.meta
@@ -200,7 +200,7 @@
   units = flag
   dimensions = (horizontal_loop_extent)
   type = logical
-  intent = inout
+  intent = in
 [u10m]
   standard_name = x_wind_at_10m
   long_name = 10 meter u wind speed


### PR DESCRIPTION
This PR is to fix the RRFS ensemble member crash when combining clm lake and GFS PBL/sfclay:

https://github.com/ufs-community/ccpp-physics/issues/141

A new flag is created to track new freezing lake ice and let sfc_diff to calculate stability variables over the new icy grids for GFS PBL in the second surface loop, which otherwise will remain as missing values.