### PR TITLE
Issue 1984 fix: reduce warnings for ccpp-physics

### DIFF
--- a/physics/GWD/unified_ugwp.F90
+++ b/physics/GWD/unified_ugwp.F90
@@ -377,6 +377,10 @@ contains
     errmsg = ''
     errflg = 0
 
+    ! Initialize variables not being used
+    zmtb(:) = 0.0
+    zlwb(:) = 0.0
+    zogb(:) = 0.0
 
     ! 1) ORO stationary GWs
     !    ------------------

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.F90
@@ -61,8 +61,7 @@
 !!
       subroutine GFS_surface_generic_pre_run (nthreads, im, levs, vfrac, islmsk, isot, ivegsrc, stype, scolor,vtype, slope, &
                           prsik_1, prslk_1, tsfc, phil, con_g, sigmaf, work3, zlvl,                        &
-                          drain_cpl, dsnow_cpl, rain_cpl, snow_cpl, lndp_type, n_var_lndp, sfc_wts,        &
-                          lndp_var_list, lndp_prt_list,                                                    &
+                          lndp_type, n_var_lndp, sfc_wts, lndp_var_list, lndp_prt_list,                    &
                           z01d, zt1d, bexp1d, xlai1d, vegf1d, lndp_vgf,                                    &
                           cplflx, flag_cice, islmsk_cice, slimskin_cpl,                                    &
                           wind, u1, v1, cnvwind, smcwlt2, smcref2, vtype_save, stype_save,scolor_save, slope_save,     &
@@ -87,10 +86,6 @@
         real(kind=kind_phys), dimension(:), intent(inout) :: sigmaf, work3, zlvl
 
         ! Stochastic physics / surface perturbations
-        real(kind=kind_phys), dimension(:),   intent(in) :: drain_cpl
-        real(kind=kind_phys), dimension(:),   intent(in) :: dsnow_cpl
-        real(kind=kind_phys), dimension(:),   intent(in)  :: rain_cpl
-        real(kind=kind_phys), dimension(:),   intent(in)  :: snow_cpl
         integer,                              intent(in)  :: lndp_type, n_var_lndp
         character(len=3),     dimension(:),   intent(in)  :: lndp_var_list
         real(kind=kind_phys), dimension(:),   intent(in)  :: lndp_prt_list

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.F90
@@ -87,8 +87,8 @@
         real(kind=kind_phys), dimension(:), intent(inout) :: sigmaf, work3, zlvl
 
         ! Stochastic physics / surface perturbations
-        real(kind=kind_phys), dimension(:),   intent(out) :: drain_cpl
-        real(kind=kind_phys), dimension(:),   intent(out) :: dsnow_cpl
+        real(kind=kind_phys), dimension(:),   intent(in) :: drain_cpl
+        real(kind=kind_phys), dimension(:),   intent(in) :: dsnow_cpl
         real(kind=kind_phys), dimension(:),   intent(in)  :: rain_cpl
         real(kind=kind_phys), dimension(:),   intent(in)  :: snow_cpl
         integer,                              intent(in)  :: lndp_type, n_var_lndp

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.meta
@@ -297,7 +297,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [dsnow_cpl]
   standard_name = tendency_of_lwe_thickness_of_snowfall_amount_on_dynamics_timestep_for_coupling
   long_name = change in show_cpl (coupling_type)
@@ -305,7 +305,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [rain_cpl]
   standard_name = cumulative_lwe_thickness_of_precipitation_amount_for_coupling
   long_name = total rain precipitation

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.meta
@@ -290,38 +290,6 @@
   type = real
   kind = kind_phys
   intent = inout
-[drain_cpl]
-  standard_name = tendency_of_lwe_thickness_of_rain_amount_on_dynamics_timestep_for_coupling
-  long_name = change in rain_cpl (coupling_type)
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
-[dsnow_cpl]
-  standard_name = tendency_of_lwe_thickness_of_snowfall_amount_on_dynamics_timestep_for_coupling
-  long_name = change in show_cpl (coupling_type)
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
-[rain_cpl]
-  standard_name = cumulative_lwe_thickness_of_precipitation_amount_for_coupling
-  long_name = total rain precipitation
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
-[snow_cpl]
-  standard_name = cumulative_lwe_thickness_of_snow_amount_for_coupling
-  long_name = total snow precipitation
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
 [lndp_type]
   standard_name = control_for_stochastic_land_surface_perturbation
   long_name = index for stochastic land surface perturbations type


### PR DESCRIPTION
## Description of Changes: 
Changes to get rid of all the warnings, as pointed out in ufs-weather-model [Issue#1984](https://github.com/ufs-community/ufs-weather-model/issues/1984#issuecomment-1799297076). The fixes for the second and third bullet points were intuited from how similar variables are treated in the code base, if different behavior is preferred please let me know!

- For all the `warning #5462: Global name too long, shortened from` warnings: this issue may be already fixed by the Intel compiler, per [their message board](https://community.intel.com/t5/Intel-Fortran-Compiler/Many-quot-Global-name-too-long-quot-warnings/m-p/1512136/highlight/true#M167584). I haven't had access to the newer Intel 2024.0.1 or 2024.0.2 versions to test.
- For varibles `zmtb, zlwb, zogw` the warning was "unified_ugwp.F90(256): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value." This fix here is they are initialized to 0.0. The following table provides justification for setting the variable to 0, it's how they are always initialized.

| file                              | line   | description                         |
|----------------------|------|---------------------------|
| ugwpv1_gsldrag.F90 |  [521](https://github.com/ufs-community/ccpp-physics/blob/0cdfc9d7465358debb4de292861fef970b44874a/physics/ugwpv1_gsldrag.F90#L521) | zlwb(:)= 0. ; zogw(:)=0.      |
| ugwp_driver_v0.F      |  [206](https://github.com/ufs-community/ccpp-physics/blob/0cdfc9d7465358debb4de292861fef970b44874a/physics/ugwp_driver_v0.F#L206) | zmtb(i)     = 0.0                  |
| cires_ugwp.F90         |  [297](https://github.com/ufs-community/ccpp-physics/blob/0cdfc9d7465358debb4de292861fef970b44874a/physics/cires_ugwp.F90#L297) | if (do_ugwp) zlwb(:)   = 0. |

- The `drain_cpl` and `dsnow_cpl` warnings were "explicit INTENT(OUT) declaration is not given an explicit value". These variables are changed from intent(out) to intent(in) variables. This is to replicate the [rain_cpl and snow_cpl variables](https://github.com/scrasmussen/ccpp-physics/blob/8414f780d1d327a81e95c0e479c3c3ceb9f300bc/physics/GFS_surface_generic_pre.F90#L92-L93).

- The `err_message` return value of two functions were not defined. The error message is defined as "" and if an error occurs in the `open` and `write` statements it will return the error message. Note: this doesn't have the additional `errflg`, as stated in the [coding rules](https://ccpp-techdoc.readthedocs.io/en/latest/CompliantPhysicsParams.html#coding-rules), figure that would be an issue for a different PR if we want it fixed?

- The last remaining warning message still needs to be fixed. It is `FV3/ccpp/physics/physics/dcyc2t3.f(184): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [ADJSFCULW]`. This is only used in [a print statement](https://github.com/ufs-community/ccpp-physics/blob/0cdfc9d7465358debb4de292861fef970b44874a/physics/dcyc2t3.f#L353-L356), so a possible fix is to change it from and `intent(out)` variable to an `intent(inout)` variable or remove it? I wasn't sure how to treat this one so would like input if possible, thanks!

## Tests Conducted: 
Testing on Derecho with Intel Fortran 2023.2.1. Result of testing is as follows: 
- Builds without the warnings described as fixed by this PR. Only seeing "Global name too long" and "ADJSFCULW not given an explicit value" warnings. 
- NOTE: Derecho CMake is doing the final linking step to the ESMF and Parallel IO libraries incorrectly. When I manually run the linking command with the correct paths to those libraries, it links correctly.
- Working on getting the [regression test script](https://ufs-weather-model.readthedocs.io/en/latest/BuildingAndRunning.html#using-the-regression-test-script) running but since it does its own build step first, it isn't working due to the linking issue in the previous bullet point. Will add a comment once the regression test script are running properly.

## Dependencies:
None

## Documentation:
No changes.

## Issue (optional): 
Fixes most issues mentioned in ufs-weather-model [Issue#1984](https://github.com/ufs-community/ufs-weather-model/issues/1984#issuecomment-1799297076).

