### PR TITLE
Remove warnings from CCPP physics

### DIFF
--- a/physics/GWD/unified_ugwp.F90
+++ b/physics/GWD/unified_ugwp.F90
@@ -253,7 +253,7 @@ contains
          cdmbgwd, jdat, xlat, xlat_d, sinlat, coslat, area,                            &
          ugrs, vgrs, tgrs, q1, prsi, prsl, prslk, phii, phil,                          &
          del, kpbl, dusfcg, dvsfcg, gw_dudt, gw_dvdt, gw_dtdt, gw_kdis,                &
-         tau_tofd, tau_mtb, tau_ogw, tau_ngw, zmtb, zlwb, zogw,                        &
+         tau_tofd, tau_mtb, tau_ogw, tau_ngw,                                          &
          dudt_mtb, dudt_tms, du3dt_mtb, du3dt_ogw, du3dt_tms,                          &
          dudt, dvdt, dtdt, rdxzb, con_g, con_omega, con_pi, con_cp, con_rd, con_rv,    &
          con_rerth, con_fvirt, rain, ntke, q_tke, dqdt_tke, lprnt, ipr,                &
@@ -309,7 +309,7 @@ contains
       &                                     slmsk(:)
 
     real(kind=kind_phys),    intent(out), dimension(:)          :: dusfcg, dvsfcg
-    real(kind=kind_phys),    intent(out), dimension(:)          :: zmtb, zlwb, zogw, rdxzb
+    real(kind=kind_phys),    intent(out), dimension(:)          :: rdxzb
     real(kind=kind_phys),    intent(out), dimension(:)          :: tau_mtb, tau_ogw, tau_tofd, tau_ngw
     real(kind=kind_phys),    intent(out), dimension(:,:)        :: gw_dudt, gw_dvdt, gw_dtdt, gw_kdis
     real(kind=kind_phys),    intent(out), dimension(:,:)        :: dudt_mtb, dudt_tms
@@ -377,10 +377,6 @@ contains
     errmsg = ''
     errflg = 0
 
-    ! Initialize variables not being used
-    zmtb(:) = 0.0
-    zlwb(:) = 0.0
-    zogb(:) = 0.0
 
     ! 1) ORO stationary GWs
     !    ------------------

--- a/physics/GWD/unified_ugwp.F90
+++ b/physics/GWD/unified_ugwp.F90
@@ -377,6 +377,10 @@ contains
     errmsg = ''
     errflg = 0
 
+    ! Initialize variables not being used
+    zmtb(:) = 0.0
+    zlwb(:) = 0.0
+    zogb(:) = 0.0
 
     ! 1) ORO stationary GWs
     !    ------------------

--- a/physics/GWD/unified_ugwp.meta
+++ b/physics/GWD/unified_ugwp.meta
@@ -900,30 +900,6 @@
   type = real
   kind = kind_phys
   intent = out
-[zmtb]
-  standard_name = height_of_mountain_blocking
-  long_name = height of mountain blocking drag
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = out
-[zlwb]
-  standard_name = height_of_low_level_wave_breaking
-  long_name = height of low level wave breaking
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = out
-[zogw]
-  standard_name = height_of_launch_level_of_orographic_gravity_wave
-  long_name = height of launch level of orographic gravity wave
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = out
 [dudt_mtb]
   standard_name = instantaneous_change_in_x_wind_due_to_mountain_blocking_drag
   long_name = instantaneous change in x wind due to mountain blocking drag

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.F90
@@ -61,8 +61,7 @@
 !!
       subroutine GFS_surface_generic_pre_run (nthreads, im, levs, vfrac, islmsk, isot, ivegsrc, stype, scolor,vtype, slope, &
                           prsik_1, prslk_1, tsfc, phil, con_g, sigmaf, work3, zlvl,                        &
-                          drain_cpl, dsnow_cpl, rain_cpl, snow_cpl, lndp_type, n_var_lndp, sfc_wts,        &
-                          lndp_var_list, lndp_prt_list,                                                    &
+                          lndp_type, n_var_lndp, sfc_wts, lndp_var_list, lndp_prt_list,                    &
                           z01d, zt1d, bexp1d, xlai1d, vegf1d, lndp_vgf,                                    &
                           cplflx, flag_cice, islmsk_cice, slimskin_cpl,                                    &
                           wind, u1, v1, cnvwind, smcwlt2, smcref2, vtype_save, stype_save,scolor_save, slope_save,     &
@@ -87,10 +86,6 @@
         real(kind=kind_phys), dimension(:), intent(inout) :: sigmaf, work3, zlvl
 
         ! Stochastic physics / surface perturbations
-        real(kind=kind_phys), dimension(:),   intent(in) :: drain_cpl
-        real(kind=kind_phys), dimension(:),   intent(in) :: dsnow_cpl
-        real(kind=kind_phys), dimension(:),   intent(in)  :: rain_cpl
-        real(kind=kind_phys), dimension(:),   intent(in)  :: snow_cpl
         integer,                              intent(in)  :: lndp_type, n_var_lndp
         character(len=3),     dimension(:),   intent(in)  :: lndp_var_list
         real(kind=kind_phys), dimension(:),   intent(in)  :: lndp_prt_list

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.F90
@@ -87,8 +87,8 @@
         real(kind=kind_phys), dimension(:), intent(inout) :: sigmaf, work3, zlvl
 
         ! Stochastic physics / surface perturbations
-        real(kind=kind_phys), dimension(:),   intent(out) :: drain_cpl
-        real(kind=kind_phys), dimension(:),   intent(out) :: dsnow_cpl
+        real(kind=kind_phys), dimension(:),   intent(in) :: drain_cpl
+        real(kind=kind_phys), dimension(:),   intent(in) :: dsnow_cpl
         real(kind=kind_phys), dimension(:),   intent(in)  :: rain_cpl
         real(kind=kind_phys), dimension(:),   intent(in)  :: snow_cpl
         integer,                              intent(in)  :: lndp_type, n_var_lndp

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.meta
@@ -297,7 +297,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [dsnow_cpl]
   standard_name = tendency_of_lwe_thickness_of_snowfall_amount_on_dynamics_timestep_for_coupling
   long_name = change in show_cpl (coupling_type)
@@ -305,7 +305,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [rain_cpl]
   standard_name = cumulative_lwe_thickness_of_precipitation_amount_for_coupling
   long_name = total rain precipitation

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.meta
@@ -290,38 +290,6 @@
   type = real
   kind = kind_phys
   intent = inout
-[drain_cpl]
-  standard_name = tendency_of_lwe_thickness_of_rain_amount_on_dynamics_timestep_for_coupling
-  long_name = change in rain_cpl (coupling_type)
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
-[dsnow_cpl]
-  standard_name = tendency_of_lwe_thickness_of_snowfall_amount_on_dynamics_timestep_for_coupling
-  long_name = change in show_cpl (coupling_type)
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
-[rain_cpl]
-  standard_name = cumulative_lwe_thickness_of_precipitation_amount_for_coupling
-  long_name = total rain precipitation
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
-[snow_cpl]
-  standard_name = cumulative_lwe_thickness_of_snow_amount_for_coupling
-  long_name = total snow precipitation
-  units = m
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = in
 [lndp_type]
   standard_name = control_for_stochastic_land_surface_perturbation
   long_name = index for stochastic land surface perturbations type

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.f
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.f
@@ -44,7 +44,7 @@
 !      input/output:                                                    !
 !            dtdt,dtdtnp,                                               !
 !      outputs:                                                         !
-!            adjsfcdsw,adjsfcnsw,adjsfcdlw,adjsfculw,                   !
+!            adjsfcdsw,adjsfcnsw,adjsfcdlw,                             !
 !            adjsfculw_lnd,adjsfculw_ice,adjsfculw_wat,xmu,xcosz,       !
 !            adjnirbmu,adjnirdfu,adjvisbmu,adjvisdfu,                   !
 !            adjdnnbmd,adjdnndfd,adjdnvbmd,adjdnvdfd)                   !
@@ -181,7 +181,7 @@
 !  ---  input/output:
      &       dtdt,dtdtnp,htrlw,                                         &
 !  ---  outputs:
-     &       adjsfcdsw,adjsfcnsw,adjsfcdlw,adjsfculw,                   &
+     &       adjsfcdsw,adjsfcnsw,adjsfcdlw,                             &
      &       adjsfculw_lnd,adjsfculw_ice,adjsfculw_wat,xmu,xcosz,       &
      &       adjnirbmu,adjnirdfu,adjvisbmu,adjvisdfu,                   &
      &       adjnirbmd,adjnirdfd,adjvisbmd,adjvisdfd,                   &
@@ -242,7 +242,7 @@
 
 !  ---  outputs:
       real(kind=kind_phys), dimension(:), intent(out) ::                &
-     &      adjsfcdsw, adjsfcnsw, adjsfcdlw, adjsfculw, xmu, xcosz,     &
+     &      adjsfcdsw, adjsfcnsw, adjsfcdlw, xmu, xcosz,                &
      &      adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,                 &
      &      adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd
 
@@ -352,7 +352,7 @@
 
 !     if (lprnt .and. i == ipr) write(0,*)' in dcyc3: dry==',dry(i)
 !    &,' wet=',wet(i),' icy=',icy(i),' tsfc3=',tsfc3(i,:)
-!    &,' sfcemis=',sfcemis(i,:),' adjsfculw=',adjsfculw(i,:)
+!    &,' sfcemis=',sfcemis(i,:)
 !
 
 !>  - normalize by average value over radiation period for daytime.

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.meta
@@ -524,14 +524,6 @@
   type = real
   kind = kind_phys
   intent = out
-[adjsfculw]
-  standard_name = surface_upwelling_longwave_flux
-  long_name = surface upwelling longwave flux at current time
-  units = W m-2
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = out
 [adjsfculw_lnd]
   standard_name = surface_upwelling_longwave_flux_over_land
   long_name = surface upwelling longwave flux at current time over land


### PR DESCRIPTION
Most credit to @scrasmussen. @Qingfu-Liu removed some unneeded variables.

## Description of Changes: 
Changes to get rid of all the warnings, as pointed out in ufs-weather-model [Issue#1984](https://github.com/ufs-community/ufs-weather-model/issues/1984#issuecomment-1799297076). The fixes for the second and third bullet points were intuited from how similar variables are treated in the code base, if different behavior is preferred please let me know!

- For all the `warning #5462: Global name too long, shortened from` warnings: this issue may be already fixed by the Intel compiler, per [their message board](https://community.intel.com/t5/Intel-Fortran-Compiler/Many-quot-Global-name-too-long-quot-warnings/m-p/1512136/highlight/true#M167584). I haven't had access to the newer Intel 2024.0.1 or 2024.0.2 versions to test.

- The `drain_cpl` and `dsnow_cpl` warnings were "explicit INTENT(OUT) declaration is not given an explicit value". These variables are changed from intent(out) to intent(in) variables. This is to replicate the [rain_cpl and snow_cpl variables](https://github.com/scrasmussen/ccpp-physics/blob/8414f780d1d327a81e95c0e479c3c3ceb9f300bc/physics/GFS_surface_generic_pre.F90#L92-L93).

- The `err_message` return value of two functions were not defined. The error message is defined as "" and if an error occurs in the `open` and `write` statements it will return the error message. Note: this doesn't have the additional `errflg`, as stated in the [coding rules](https://ccpp-techdoc.readthedocs.io/en/latest/CompliantPhysicsParams.html#coding-rules), figure that would be an issue for a different PR if we want it fixed?

- The last remaining warning message still needs to be fixed. It is `FV3/ccpp/physics/physics/dcyc2t3.f(184): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [ADJSFCULW]`. This is only used in [a print statement](https://github.com/ufs-community/ccpp-physics/blob/0cdfc9d7465358debb4de292861fef970b44874a/physics/dcyc2t3.f#L353-L356); removed [ADJSFCULW]

## Tests Conducted: 
Testing on Derecho with Intel Fortran 2023.2.1. Result of testing is as follows: 
- Builds without the warnings described as fixed by this PR. Only seeing "Global name too long" and "ADJSFCULW not given an explicit value" warnings. 
- NOTE: Derecho CMake is doing the final linking step to the ESMF and Parallel IO libraries incorrectly. When I manually run the linking command with the correct paths to those libraries, it links correctly.
- Working on getting the [regression test script](https://ufs-weather-model.readthedocs.io/en/latest/BuildingAndRunning.html#using-the-regression-test-script) running but since it does its own build step first, it isn't working due to the linking issue in the previous bullet point. Will add a comment once the regression test script are running properly.

## Dependencies:
None

## Documentation:
No changes.

## Issue (optional): 
Fixes most issues mentioned in ufs-weather-model [Issue#1984](https://github.com/ufs-community/ufs-weather-model/issues/1984#issuecomment-1799297076).