### PR TITLE
[production/AQM.v7] More EE2 compliance for removal of -nowarn in non-debug builds

### DIFF
--- a/physics/GFS_surface_generic_pre.F90
+++ b/physics/GFS_surface_generic_pre.F90
@@ -86,8 +86,8 @@
         real(kind=kind_phys), dimension(:), intent(inout) :: sigmaf, work3, zlvl
 
         ! Stochastic physics / surface perturbations
-        real(kind=kind_phys), dimension(:),   intent(out) :: drain_cpl
-        real(kind=kind_phys), dimension(:),   intent(out) :: dsnow_cpl
+        real(kind=kind_phys), dimension(:),   intent(inout) :: drain_cpl
+        real(kind=kind_phys), dimension(:),   intent(inout) :: dsnow_cpl
         real(kind=kind_phys), dimension(:),   intent(in)  :: rain_cpl
         real(kind=kind_phys), dimension(:),   intent(in)  :: snow_cpl
         integer,                              intent(in)  :: lndp_type, n_var_lndp

--- a/physics/dcyc2t3.f
+++ b/physics/dcyc2t3.f
@@ -247,9 +247,11 @@
 
 !  ---  outputs:
       real(kind=kind_phys), dimension(:), intent(out) ::                &
-     &      adjsfcdsw, adjsfcnsw, adjsfcdlw, adjsfculw, xmu, xcosz,     &
+     &      adjsfcdsw, adjsfcnsw, adjsfcdlw, xmu, xcosz,                &
      &      adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,                 &
      &      adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd
+
+      real(kind=kind_phys), dimension(:), intent(inout) :: adjsfculw
 
       real(kind=kind_phys), dimension(:), intent(out) ::                &
      &      adjsfculw_lnd, adjsfculw_ice, adjsfculw_wat

--- a/physics/progsigma_calc.f90
+++ b/physics/progsigma_calc.f90
@@ -34,8 +34,8 @@
 !     intent out
       real(kind=kind_phys), intent(out) :: sigmaout(im,km)
       real(kind=kind_phys), intent(out) :: sigmab(im)
-      character(len=*),     intent(out) :: errmsg
-      integer,              intent(out) :: errflg
+      character(len=*),     intent(inout) :: errmsg
+      integer,              intent(inout) :: errflg
 
 !     Local variables
       integer              :: i,k,km1


### PR DESCRIPTION
Taking care of warnings after removing '-nowarn' from non-debug builds

Most variables were unused and unset, so switching from OUT to INOUT fixed the warnings.

This is not a permanent solution, as a permanent solution will come into the develop branch later.