### PR TITLE
[production/RRFS.v1] fix zero cloud fraction for RRFS ensemble members 

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/sgscloud_radpre.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/sgscloud_radpre.F90
@@ -55,7 +55,7 @@
            nlay, plyr, xlat, dz,de_lgth, &
            cldsa,mtopa,mbota,            &
            imp_physics, imp_physics_gfdl,&
-           imp_physics_fa,               &
+           imp_physics_fa, conv_cf_opt,  &
            iovr,                         &
            errmsg, errflg                )
 
@@ -75,7 +75,7 @@
       real(kind=kind_phys)             :: gfac
       integer,             intent(in)  :: im, levs, imfdeepcnv, imfdeepcnv_gf, &
            &  nlay, imfdeepcnv_sas, imfdeepcnv_c3, imp_physics, & 
-           &  imp_physics_gfdl, imp_physics_fa
+           &  imp_physics_gfdl, imp_physics_fa, conv_cf_opt
       logical,             intent(in)  :: flag_init, flag_restart, do_mynnedmf
 
       real(kind=kind_phys), dimension(:,:), intent(inout) :: qc, qi
@@ -119,9 +119,6 @@
       !Chaboureau and Bechtold (2002 and 2005)
       real :: a, f, sigq, qmq, qt, xl, th, thl, rsl, cpm, cb_cf
       real(kind=kind_phys) :: tlk
-
-      !Option to convective cloud fraction
-      integer, parameter :: conv_cf_opt = 0  !0: C-B, 1: X-R
 
       ! Initialize CCPP error handling variables
       errmsg = ''

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/sgscloud_radpre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/sgscloud_radpre.meta
@@ -273,6 +273,13 @@
   dimensions = ()
   type = integer
   intent = in
+[conv_cf_opt]
+  standard_name = option_for_convection_scheme_cloud_fraction_computation 
+  long_name = option for convection scheme cloud fraction computation
+  units = flag
+  dimensions = ()
+  type = integer
+  intent = in
 [qc_save]
   standard_name = cloud_condensed_water_mixing_ratio_save
   long_name = ratio of mass of cloud water to mass of dry air plus vapor (without condensates) before entering a physics scheme


### PR DESCRIPTION
This PR will address zero cloud fraction issue for RRFS ensemble members using GFS PBL and G-F convection by adding SGS cloud to ccpp SDF and changing conv_cf_opt to Xu-Randall for convective cloud fraction computation for those members.

The change to ccpp-physics is to add conv_cf_opt as an input namelist parameter for runtime switch (conv_cf_opt=1 for GFS PBL members).

ccpp-physics issue:
https://github.com/ufs-community/ccpp-physics/issues/185

Several tests for a single case (init 2023/05/10/06Z) have been performed by:
1. using progcld_thompson_wsm6 in radiation_clouds.f
2. using sgscloud_radpre with CB
3. using sgscloud_radpre with XR

Here are total/low/medium/high cloud fractions and downward short wave radiation flux at surface:
[cldfra_comparison_f24.pptx](https://github.com/ufs-community/ccpp-physics/files/14591164/cldfra_comparison_f24.pptx)
[cldfra_comparison_f36.pptx](https://github.com/ufs-community/ccpp-physics/files/14591165/cldfra_comparison_f36.pptx)
[dswrfsfc.pptx](https://github.com/ufs-community/ccpp-physics/files/14591166/dswrfsfc.pptx)
