### PR TITLE
[production/RRFS.v1] Fix improperly assigned fire emissions for ebb_dcycle==1 for retrospectives (NOT operational!)

### DIFF
--- a/physics/smoke_dust/module_add_emiss_burn.F90
+++ b/physics/smoke_dust/module_add_emiss_burn.F90
@@ -66,15 +66,6 @@ CONTAINS
     timeq= mod(timeq,timeq_max)
     coef_con=1._kind_phys/((2._kind_phys*pi)**0.5)
 
-! RAR: for option #1 ebb and frp are ingested for 24 hours. No modification is applied! 
-    if (ebb_dcycle==1) then
-      do k=kts,kte
-        do i=its,ite
-         ebu(i,k,1)=ebu_in(i,1)  
-        enddo
-      enddo
-     endif
-
     if (ebb_dcycle==2) then
     
      do j=jts,jte


### PR DESCRIPTION
For ebb_dcycle==1 (retrospective fire emissions), the 3-d emissions were incorrectly assgined assigned at all levels using the surface data. 

This address Issue #188 