### PR TITLE
fixed excessive evaporation when both innerloop=T and mraerosol=T

### DIFF
--- a/physics/MP/Thompson/module_mp_thompson.F90
+++ b/physics/MP/Thompson/module_mp_thompson.F90
@@ -3587,7 +3587,7 @@ MODULE module_mp_thompson
 
 !+---+-----------------------------------------------------------------+ !  EVAPORATION
            elseif (clap .lt. -eps .AND. ssatw(k).lt.-1.E-6 .AND.     &
-                  (is_aerosol_aware .or. merra2_aerosol_aware)) then  
+                  (is_aerosol_aware)) then  
             tempc = temp(k) - 273.15
             otemp = 1./temp(k)
             rvs = rho(k)*qvs(k)

--- a/physics/MP/Thompson/module_mp_thompson.F90
+++ b/physics/MP/Thompson/module_mp_thompson.F90
@@ -3587,7 +3587,7 @@ MODULE module_mp_thompson
 
 !+---+-----------------------------------------------------------------+ !  EVAPORATION
            elseif (clap .lt. -eps .AND. ssatw(k).lt.-1.E-6 .AND.     &
-                  (is_aerosol_aware)) then  
+                  is_aerosol_aware) then  
             tempc = temp(k) - 273.15
             otemp = 1./temp(k)
             rvs = rho(k)*qvs(k)


### PR DESCRIPTION
One line of code modification fixing the excessive evaporation problem when both Innerloop and mraerosol is T