### PR TITLE
Make ozone photochem diagnostics match parametrization terms

### DIFF
--- a/physics/photochem/module_ozphys.F90
+++ b/physics/photochem/module_ozphys.F90
@@ -306,8 +306,8 @@ contains
 
        ! Diagnostics (optional)
        if (do_diag) then
-          do3_dt_prd(:,iLev)  = (prod(:,1)-prod(:,2)*prod(:,6))*dt
-          do3_dt_ozmx(:,iLev) = (oz(:,iLev) - ozib(:))
+          do3_dt_prd(:,iLev)  = prod(:,1) * dt
+          do3_dt_ozmx(:,iLev) = prod(:,2) * (oz(:,iLev) - prod(:,6)) * dt
           do3_dt_temp(:,iLev) = prod(:,3)*(t(:,iLev)-prod(:,5))*dt
           do3_dt_ohoz(:,iLev) = prod(:,4) * (colo3(:,iLev)-coloz(:,iLev))*dt
        endif


### PR DESCRIPTION
The ozone photochemistry parametrization is a first-order Taylor expansion of the net ozone production in three variables.  This commit changes the four diagnostics the parametrization manages to match the four terms in the Taylor expansion.

When comparing to the implementation in lines 301-304, note that it is implicit in the model ozone mixing ratio, so line 301 has the first term and the second half of the second term, while the first half of the second term is part of the denominator on line 304.

I could use `ozi` or `ozib` for an explicit approximation to that term, but we already calculated the value needed for the implicit calculation actually used for the update.

I was told to open the PR here rather than the NCAR repository (NCAR/ccpp-physics#1068)