### PR TITLE
[production/RRFS.v1] Add clear-sky shortwave downward at surface flux to available diagnostics.

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_debug.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_debug.F90
@@ -688,6 +688,7 @@
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%dlwsfci     ',    Diag%dlwsfci)
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%ulwsfci     ',    Diag%ulwsfci)
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%dswsfci     ',    Diag%dswsfci)
+                     call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%dswsfcci    ',    Diag%dswsfcci)
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%nswsfci     ',    Diag%nswsfci)
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%uswsfci     ',    Diag%uswsfci)
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%dusfci      ',    Diag%dusfci)

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.f
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.f
@@ -36,7 +36,7 @@
 !          ( solhr,slag,sdec,cdec,sinlat,coslat,                        !
 !            xlon,coszen,tsfc_lnd,tsfc_ice,tsfc_wat,                    !
 !            tf,tsflw,sfcemis_lnd,sfcemis_ice,sfcemis_wat,              !
-!            sfcdsw,sfcnsw,sfcdlw,sfculw,swh,swhc,hlw,hlwc,             !
+!            sfcdsw,sfcdswc,sfcnsw,sfcdlw,sfculw,swh,swhc,hlw,hlwc,     !
 !            sfcnirbmu,sfcnirdfu,sfcvisbmu,sfcvisdfu,                   !
 !            sfcnirbmd,sfcnirdfd,sfcvisbmd,sfcvisdfd,                   !
 !            im, levs, deltim, fhswr,                                   !
@@ -44,7 +44,7 @@
 !      input/output:                                                    !
 !            dtdt,dtdtnp,                                               !
 !      outputs:                                                         !
-!            adjsfcdsw,adjsfcnsw,adjsfcdlw,adjsfculw,                   !
+!            adjsfcdsw,adjsfcdswc,adjsfcnsw,adjsfcdlw,                  !
 !            adjsfculw_lnd,adjsfculw_ice,adjsfculw_wat,xmu,xcosz,       !
 !            adjnirbmu,adjnirdfu,adjvisbmu,adjvisdfu,                   !
 !            adjdnnbmd,adjdnndfd,adjdnvbmd,adjdnvdfd)                   !
@@ -68,6 +68,7 @@
 !     sfcemis_wat(im) - real, surface emissivity (fraction) o. ocean (k)!
 !     tsflw  (im)  - real, sfc air (layer 1) temp in k saved in lw call !
 !     sfcdsw (im)  - real, total sky sfc downward sw flux ( w/m**2 )    !
+!     sfcdswc (im) - real, clear sky sfc downward sw flux ( w/m**2 )    !
 !     sfcnsw (im)  - real, total sky sfc net sw into ground (w/m**2)    !
 !     sfcdlw (im)  - real, total sky sfc downward lw flux ( w/m**2 )    !
 !     sfculw (im)  - real, total sky sfc upward lw flux ( w/m**2 )    !
@@ -98,6 +99,7 @@
 !                                                                       !
 !  outputs:                                                             !
 !     adjsfcdsw(im)- real, time step adjusted sfc dn sw flux (w/m**2)   !
+!     adjsfcdswc(im)- real, time step adjusted sfc dn sw flux (w/m**2)  !
 !     adjsfcnsw(im)- real, time step adj sfc net sw into ground (w/m**2)!
 !     adjsfcdlw(im)- real, time step adjusted sfc dn lw flux (w/m**2)   !
 !     adjsfculw_lnd(im)- real, sfc upw. lw flux at current time (w/m**2)!
@@ -169,7 +171,7 @@
      &       con_g, con_cp, con_pi, con_sbc,                            &
      &       xlon,coszen,tsfc_lnd,tsfc_ice,tsfc_wat,tf,tsflw,tsfc,      &
      &       sfcemis_lnd, sfcemis_ice, sfcemis_wat,                     &
-     &       sfcdsw,sfcnsw,sfcdlw,swh,swhc,hlw,hlwc,                    &
+     &       sfcdsw,sfcdswc,sfcnsw,sfcdlw,swh,swhc,hlw,hlwc,            &
      &       sfcnirbmu,sfcnirdfu,sfcvisbmu,sfcvisdfu,                   &
      &       sfcnirbmd,sfcnirdfd,sfcvisbmd,sfcvisdfd,                   &
      &       im, levs, deltim, fhswr,                                   &
@@ -181,7 +183,7 @@
 !  ---  input/output:
      &       dtdt,dtdtnp,htrlw,                                         &
 !  ---  outputs:
-     &       adjsfcdsw,adjsfcnsw,adjsfcdlw,adjsfculw,                   &
+     &       adjsfcdsw,adjsfcdswc,adjsfcnsw,adjsfculw,adjsfcdlw,        &
      &       adjsfculw_lnd,adjsfculw_ice,adjsfculw_wat,xmu,xcosz,       &
      &       adjnirbmu,adjnirdfu,adjvisbmu,adjvisdfu,                   &
      &       adjnirbmd,adjnirdfd,adjvisbmd,adjvisdfd,                   &
@@ -213,8 +215,9 @@
      &     deltim, fhswr, lfnc_k, lfnc_p0
 
       real(kind=kind_phys), dimension(:), intent(in) ::                 &
-     &      sinlat, coslat, xlon, coszen, tf, tsflw, sfcdlw,            &
-     &      sfcdsw, sfcnsw, sfculw, sfculw_med, tsfc, tsfc_radtime
+     &     sinlat, coslat, xlon, coszen, tf, tsflw, sfcdlw,             &
+     &     sfcdsw, sfcdswc, sfcnsw, sfculw, sfculw_med, tsfc,           &
+     &     tsfc_radtime
 
       real(kind=kind_phys), dimension(:), intent(in) ::                 &
      &                         tsfc_lnd, tsfc_ice, tsfc_wat,            &
@@ -244,7 +247,7 @@
       real(kind=kind_phys), dimension(:), intent(out) ::                &
      &      adjsfcdsw, adjsfcnsw, adjsfcdlw, adjsfculw, xmu, xcosz,     &
      &      adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,                 &
-     &      adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd
+     &      adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfcdswc
 
       real(kind=kind_phys), dimension(:), intent(out) ::                &
      &      adjsfculw_lnd, adjsfculw_ice, adjsfculw_wat
@@ -367,6 +370,7 @@
 
         adjsfcnsw(i) = sfcnsw(i)    * xmu(i)
         adjsfcdsw(i) = sfcdsw(i)    * xmu(i)
+        adjsfcdswc(i)= sfcdswc(i)   * xmu(i)
 
         adjnirbmu(i) = sfcnirbmu(i) * xmu(i)
         adjnirdfu(i) = sfcnirdfu(i) * xmu(i)

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.meta
@@ -191,6 +191,14 @@
   type = real
   kind = kind_phys
   intent = in
+[sfcdswc]
+  standard_name = surface_downwelling_shortwave_flux_on_radiation_timestep_assuming_clear_sky
+  long_name = clear sky surface downwelling shortwave flux on radiation time step
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
 [sfcdlw]
   standard_name = surface_downwelling_longwave_flux_on_radiation_timestep
   long_name = total sky surface downwelling longwave flux on radiation time step
@@ -503,6 +511,14 @@
 [adjsfcdsw]
   standard_name = surface_downwelling_shortwave_flux
   long_name = surface downwelling shortwave flux at current time
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[adjsfcdswc]
+  standard_name = surface_downwelling_shortwave_flux_assuming_clear_sky
+  long_name = surface downwelling shortwave flux at current time assuming clear sky
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real

--- a/physics/Radiation/RRTMG/rrtmg_sw_post.F90
+++ b/physics/Radiation/RRTMG/rrtmg_sw_post.F90
@@ -14,7 +14,7 @@
                  swhtr, sfcalb1, sfcalb2, sfcalb3, sfcalb4, htswc, htsw0,      &
                  nirbmdi, nirdfdi, visbmdi, visdfdi, nirbmui, nirdfui, visbmui,&
                  visdfui, sfcdsw, sfcnsw, htrsw, swhc, scmpsw, sfcfsw, topfsw, &
-                 errmsg, errflg)
+                 sfcdswc, errmsg, errflg)
 
       use machine,                   only: kind_phys
       use module_radsw_parameters,   only: topfsw_type, sfcfsw_type,   &
@@ -33,7 +33,8 @@
                                                              visbmdi, visdfdi, &
                                                              nirbmui, nirdfui, &
                                                              visbmui, visdfui, &
-                                                             sfcdsw,  sfcnsw
+                                                             sfcdsw,  sfcnsw,  &
+                                                             sfcdswc
       real(kind=kind_phys), dimension(:,:), intent(inout) :: htrsw, swhc
 
       type(cmpfsw_type), dimension(:),     intent(inout) :: scmpsw
@@ -122,6 +123,7 @@
         do i=1,im
           sfcnsw(i) = sfcfsw(i)%dnfxc - sfcfsw(i)%upfxc
           sfcdsw(i) = sfcfsw(i)%dnfxc
+          sfcdswc(i)= sfcfsw(i)%dnfx0
         enddo
 
       endif                                ! end_if_lsswr

--- a/physics/Radiation/RRTMG/rrtmg_sw_post.meta
+++ b/physics/Radiation/RRTMG/rrtmg_sw_post.meta
@@ -198,6 +198,14 @@
   type = real
   kind = kind_phys
   intent = inout
+[sfcdswc]
+  standard_name = surface_downwelling_shortwave_flux_on_radiation_timestep_assuming_clear_sky
+  long_name = clear sky sfc downward sw flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
 [htrsw]
   standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
   long_name = total sky sw heating rate


### PR DESCRIPTION
This PR adds a new diagnostic, instantaneous downward shortwave flux at the surface assuming clear-sky conditions.
This is needed for RRFSv1.
Analogous to #197 into ufs/dev