### PR TITLE
Fix incorrect intents.

### DIFF
--- a/physics/GWD/gwdps.meta
+++ b/physics/GWD/gwdps.meta
@@ -373,7 +373,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [ldiag_ugwp]
   standard_name = flag_for_unified_gravity_wave_physics_diagnostics
   long_name = flag for CIRES UGWP Diagnostics

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_DCNV_generic_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_DCNV_generic_pre.meta
@@ -126,7 +126,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.F90
@@ -43,10 +43,10 @@
       integer, intent(in) :: index_of_temperature,index_of_process_mp,use_lake_model(:)
       integer, intent(in) :: imfshalcnv,imfshalcnv_gf,imfdeepcnv,imfdeepcnv_gf,imfdeepcnv_samf
       integer, dimension (:), intent(in) :: htop
-      integer                                                :: dfi_radar_max_intervals
+      integer,                                 intent(in)    :: dfi_radar_max_intervals
       real(kind=kind_phys),                    intent(in)    :: fh_dfi_radar(:), fhour, con_t0c
       real(kind=kind_phys),                    intent(in)    :: radar_tten_limits(:)
-      integer                                                :: ix_dfi_radar(:)
+      integer,                                 intent(in)    :: ix_dfi_radar(:)
       real(kind=kind_phys), dimension(:,:),    intent(inout) :: gt0,refl_10cm
 
       real(kind=kind_phys),                    intent(in)    :: dtf, frain, con_g, rainmin, rhowater

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.F90
@@ -27,7 +27,7 @@
         totprcp, totice, totsnw, totgrp, cnvprcpb, totprcpb, toticeb, totsnwb, totgrpb, rain_cpl, rainc_cpl, snow_cpl,    &
         pwat, frzr, frzrb, frozr, frozrb, tsnowp, tsnowpb, rhonewsn1, exticeden,                                          & 
         drain_cpl, dsnow_cpl, lsm, lsm_ruc, lsm_noahmp, raincprv, rainncprv, iceprv, snowprv,                             &
-        graupelprv, draincprv, drainncprv, diceprv, dsnowprv, dgraupelprv, dtp, dfi_radar_max_intervals,                  &
+        graupelprv, draincprv, drainncprv, diceprv, dsnowprv, dgraupelprv, dtp,                                           &
         dtend, dtidx, index_of_temperature, index_of_process_mp,ldiag3d, qdiag3d,dqdt_qmicro, lssav, num_dfi_radar,       &
         fh_dfi_radar,index_of_process_dfi_radar, ix_dfi_radar, dfi_radar_tten, radar_tten_limits, fhour, prevsq,      &
         iopt_lake, iopt_lake_clm, lkm, use_lake_model, errmsg, errflg)
@@ -43,7 +43,6 @@
       integer, intent(in) :: index_of_temperature,index_of_process_mp,use_lake_model(:)
       integer, intent(in) :: imfshalcnv,imfshalcnv_gf,imfdeepcnv,imfdeepcnv_gf,imfdeepcnv_samf
       integer, dimension (:), intent(in) :: htop
-      integer,                                 intent(in)    :: dfi_radar_max_intervals
       real(kind=kind_phys),                    intent(in)    :: fh_dfi_radar(:), fhour, con_t0c
       real(kind=kind_phys),                    intent(in)    :: radar_tten_limits(:)
       integer,                                 intent(in)    :: ix_dfi_radar(:)

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
@@ -229,7 +229,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [prsl]
   standard_name = air_pressure
   long_name = layer mean pressure

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
@@ -229,7 +229,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [prsl]
   standard_name = air_pressure
   long_name = layer mean pressure
@@ -430,7 +430,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [rain0]
   standard_name = lwe_thickness_of_explicit_rain_amount
   long_name = explicit rain on physics timestep

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
@@ -772,13 +772,6 @@
   type = real
   kind = kind_phys
   intent = in
-[dfi_radar_max_intervals]
-  standard_name = maximum_number_of_radar_derived_temperature_or_convection_suppression_intervals
-  long_name = maximum allowed number of time ranges with radar-derived microphysics temperature tendencies or radar-derived convection suppression
-  units = count
-  dimensions = ()
-  type = integer
-  intent = in
 [num_dfi_radar]
   standard_name = number_of_radar_derived_temperature_or_convection_suppression_intervals
   long_name = number of time ranges with radar-derived microphysics temperature tendencies or radar-derived convection suppression

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.F90
@@ -41,7 +41,7 @@ contains
       logical,                              intent(in) :: cplflx, frac_grid, cplwav2atm, frac_ice
       logical,                              intent(in) :: lheatstrg
       logical, dimension(:),                intent(in) :: flag_cice, dry, icy
-      logical, dimension(:),             intent(inout) :: wet
+      logical, dimension(:),                intent(in) :: wet
       integer, dimension(:),                intent(in) :: islmsk, use_lake_model
       real(kind=kind_phys), dimension(:),   intent(in) :: wind, t1, q1, prsl1, landfrac, lakefrac, oceanfrac,                   &
         cd_wat, cd_lnd, cd_ice, cdq_wat, cdq_lnd, cdq_ice, rb_wat, rb_lnd, rb_ice, stress_wat,                                  &

--- a/physics/PBL/MYNN_EDMF/mynnedmf_wrapper.F90
+++ b/physics/PBL/MYNN_EDMF/mynnedmf_wrapper.F90
@@ -172,7 +172,7 @@ SUBROUTINE mynnedmf_wrapper_run(        &
      implicit none
 !------------------------------------------------------------------- 
 
-     real(kind_phys)               :: huge
+     real(kind_phys),  intent(in)  :: huge
      character(len=*), intent(out) :: errmsg
      integer, intent(out)          :: errflg
 
@@ -290,7 +290,7 @@ SUBROUTINE mynnedmf_wrapper_run(        &
       real(kind_phys), dimension(:), intent(inout) :: frp
       logical, intent(in) :: mix_chem, enh_mix, rrfs_sd
       real(kind_phys), dimension(:,:,:), intent(inout) :: chem3d
-      real(kind_phys), dimension(:,:  ), intent(inout) :: vdep
+      real(kind_phys), dimension(:,:  ), intent(in) :: vdep
       real(kind_phys), dimension(im)   :: emis_ant_no
 
 !MYNN-2D

--- a/physics/PBL/SATMEDMF/satmedmfvdif.meta
+++ b/physics/PBL/SATMEDMF/satmedmfvdif.meta
@@ -503,7 +503,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/PBL/SATMEDMF/satmedmfvdifq.meta
+++ b/physics/PBL/SATMEDMF/satmedmfvdifq.meta
@@ -625,7 +625,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/PBL/SHOC/moninshoc.meta
+++ b/physics/PBL/SHOC/moninshoc.meta
@@ -456,7 +456,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/PBL/YSU/ysuvdif.meta
+++ b/physics/PBL/YSU/ysuvdif.meta
@@ -466,7 +466,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/SFC_Layer/UFS/sfc_diag.meta
+++ b/physics/SFC_Layer/UFS/sfc_diag.meta
@@ -218,7 +218,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [tskin]
   standard_name = surface_skin_temperature
   long_name = surface skin temperature
@@ -314,7 +314,7 @@
   long_name = model 2m diagnostics use the temperature and humidity calculated by the lake model
   units = flag
   dimensions = ()
-  type = integer
+  type = logical
   intent = in
 [wind]
   standard_name = wind_speed_at_lowest_model_layer

--- a/physics/SFC_Layer/UFS/sfc_diag_post.F90
+++ b/physics/SFC_Layer/UFS/sfc_diag_post.F90
@@ -28,7 +28,7 @@
         logical             , dimension(:),  intent(in) :: dry
         real(kind=kind_phys), dimension(:),  intent(in) :: pgr, u10m, v10m
         real(kind=kind_phys), dimension(:),  intent(inout) :: t2m, q2m, tmpmin, tmpmax, spfhmin, spfhmax
-        real(kind=kind_phys), dimension(:),  intent(inout) :: t2mmp, q2mp
+        real(kind=kind_phys), dimension(:),  intent(in)    :: t2mmp, q2mp
         real(kind=kind_phys), dimension(:),  intent(inout) :: wind10mmax, u10mmax, v10mmax, dpt2m
 
         character(len=*),                     intent(out) :: errmsg

--- a/physics/SFC_Layer/UFS/sfc_diag_post.meta
+++ b/physics/SFC_Layer/UFS/sfc_diag_post.meta
@@ -96,7 +96,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [q2mp]
   standard_name = specific_humidity_at_2m_from_noahmp
   long_name = 2 meter specific humidity from noahmp
@@ -104,7 +104,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [t2m]
   standard_name = air_temperature_at_2m
   long_name = 2 meter temperature


### PR DESCRIPTION
Some inconsistencies in fortran/metadata were discovered when using Capgen. Capgen's Fortran parser uncovered these mismatch in argument intents.