### PR TITLE
sfcsub.F - Fix the setting of model landmask when interpolating GLDAS data

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
@@ -7670,7 +7670,7 @@ cjfe
                   ! points.  so for efficiency, don't have fixrdc try to
                   ! find a value at landice points as defined by the vet type (vet).
               allocate(slmask_noice(len))
-              slmask_noice = 1.0
+              slmask_noice = slmskl
               do i = 1, len
                 if (nint(vet(i)) < 1 .or.
      &              nint(vet(i)) == landice_cat) then


### PR DESCRIPTION
The model land mask was set incorrectly when interpolating GLDAS data.  See
#199 for a description of the problem and solution.

Fixes #199.

Related PRs:

- https://github.com/NOAA-EMC/fv3atm/pull/827
- https://github.com/ufs-community/ufs-weather-model/pull/2253