### PR TITLE
Combination PR for ozone diagnostics, metadata intent bugfixes, sfcsub.F landmask bugfix, and canopy resistance output

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,8 +31,8 @@ physics/GWD/gwdc.*                                                           @So
 physics/GWD/gwdps.*                                                          @Songyou184                               @grantfirl @Qingfu-Liu @dustinswales
 physics/GWD/rayleigh_damp.*                                                  @yangfanglin                              @grantfirl @Qingfu-Liu @dustinswales
 physics/GWD/ugwp_driver_v0.F                                                 @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
-physics/GWD/ugwpv1_gsldrag.*                                                 @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
-physics/GWD/ugwpv1_gsldrag_post.*                                            @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/ugwpv1_gsldrag.*                                                 @mdtoyNOAA @BoYang-NOAA                   @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/ugwpv1_gsldrag_post.*                                            @mdtoyNOAA @BoYang-NOAA                   @grantfirl @Qingfu-Liu @dustinswales
 physics/GWD/unified_ugwp*                                                    @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
 physics/MP/Ferrier_Aligo/module_MP_FER_HIRES.*                               @ericaligo-NOAA                           @grantfirl @Qingfu-Liu @dustinswales
 physics/MP/Ferrier_Aligo/mp_fer_hires.*                                      @ericaligo-NOAA                           @grantfirl @Qingfu-Liu @dustinswales

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,192 +11,187 @@
 #   https://docs.google.com/spreadsheets/d/14y0Th_sSpCqlssEMNfSZ_Ni9wrpPqfpPY0kRG7jCZB8/edit#gid=0
 # (Internal NOAA document.)
 
-smoke_dust/*                                   @haiqinli                            @grantfirl @Qingfu-Liu @dustinswales
-physics/aer_cloud.F                            @AnningCheng-NOAA @andrewgettelman   @grantfirl @Qingfu-Liu @dustinswales
-physics/aerclm_def.F                           @AnningCheng-NOAA @andrewgettelman   @grantfirl @Qingfu-Liu @dustinswales
-physics/aerinterp.F90                          @AnningCheng-NOAA @andrewgettelman   @grantfirl @Qingfu-Liu @dustinswales
-physics/bl_mynn_common.f90                     @joeolson42                          @grantfirl @Qingfu-Liu @dustinswales
-physics/calpreciptype.f90                                                           @grantfirl @Qingfu-Liu @dustinswales
-physics/cires_orowam2017.f                     @mdtoyNOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/cires_tauamf_data.F90                  @mdtoyNOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/cires_ugwp*                            @mdtoyNOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/cldmacro.F                             @AnningCheng-NOAA @andrewgettelman   @grantfirl @Qingfu-Liu @dustinswales
-physics/cldwat2m_micro.F                       @AnningCheng-NOAA @andrewgettelman   @grantfirl @Qingfu-Liu @dustinswales
-physics/clm_lake.*                             @tanyasmirnova @SamuelTrahanNOAA     @grantfirl @Qingfu-Liu @dustinswales
-physics/cnvc90.*                                                                    @grantfirl @Qingfu-Liu @dustinswales
-physics/cs_conv_aw_adj.*                       @AnningCheng-NOAA                    @grantfirl @Qingfu-Liu @dustinswales
-physics/cs_conv.*                              @AnningCheng-NOAA                    @grantfirl @Qingfu-Liu @dustinswales
-physics/cu_gf*                                 @haiqinli                            @grantfirl @Qingfu-Liu @dustinswales
-physics/cu_ntiedtke*                           @JongilHan66 @Qingfu-Liu             @grantfirl @Qingfu-Liu @dustinswales
-physics/cu_c3*                                 @lisa-bengtsson @haiqinli            @grantfirl @Qingfu-Liu @dustinswales
-physics/date_def.f                             @XuLi-NOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/dcyc2t3.*                              @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/drag_suite.*                           @mdtoyNOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/flake*                                 @barlage                             @grantfirl @Qingfu-Liu @dustinswales
-physics/funcphys.f90                                                                @grantfirl @Qingfu-Liu @dustinswales
-physics/fv_sat_adj.*                           @RuiyuSun                            @grantfirl @Qingfu-Liu @dustinswales
-physics/gcycle.F90                                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/get_phi_fv3.*                                                               @grantfirl @Qingfu-Liu @dustinswales
-physics/get_prs_fv3.*                                                               @grantfirl @Qingfu-Liu @dustinswales
-physics/gfdl_cloud_microphys.*                 @RuiyuSun                            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFDL_parse_tracers.F90                                                      @grantfirl @Qingfu-Liu @dustinswales
-physics/gfdl_sfc_layer.*                       @ZhanZhang-NOAA                      @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_cloud_diagnostics.*                @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_DCNV_generic_post.*                                                     @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_DCNV_generic_pre.*                                                      @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_debug.*                                                                 @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_GWD_generic_post.*                                                      @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_GWD_generic_pre.*                                                       @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_MP_generic_post.*                                                       @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_MP_generic_pre.*                                                        @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_PBL_generic_common.F90                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_PBL_generic_post.*                                                      @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_PBL_generic_pre.*                                                       @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_phys_time_vary.fv3.*                                                    @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_phys_time_vary.scm.*                                                    @grantfirl @Qingfu-Liu @dustinswales
-physics/gfs_phy_tracer_config.F                                                     @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_radiation_surface.*                                                     @grantfirl @Qingfu-Liu @dustinswales 
-physics/GFS_rad_time_vary.fv3.*                                                     @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_rad_time_vary.scm.*                                                     @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_rrtmgp_cloud_mp.*                  @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_rrtmgp_cloud_overlap.*             @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_rrtmg_post.*                       @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_rrtmgp_pre.*                       @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_rrtmg_pre.*                        @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_rrtmgp_setup.*                     @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_rrtmgp_post.*                      @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_rrtmg_setup.*                      @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_SCNV_generic_post.*                                                     @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_SCNV_generic_pre.*                                                      @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_stochastics.*                      @pjpegion @lisa-bengtsson            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_suite_interstitial_1.*                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_suite_interstitial_2.*                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_suite_interstitial_3.*                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_suite_interstitial_4.*                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_suite_interstitial_5.*                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_suite_interstitial_phys_reset.*                                         @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_suite_interstitial_rad_reset.*                                          @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_suite_stateout_reset.*                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_suite_stateout_update.*                                                 @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_surface_composites_inter.*                                              @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_surface_composites_post.*                                               @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_surface_composites_pre.*                                                @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_surface_generic_post.*                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_surface_generic_pre.*                                                   @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_surface_loop_control_part1.*                                            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_surface_loop_control_part2.*                                            @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_time_vary_pre.fv3.*                                                     @grantfirl @Qingfu-Liu @dustinswales
-physics/GFS_time_vary_pre.scm.*                                                     @grantfirl @Qingfu-Liu @dustinswales
-physics/gocart_tracer_config_stub.f                                                 @grantfirl @Qingfu-Liu @dustinswales
-physics/gwdc.*                                 @Songyou184                          @grantfirl @Qingfu-Liu @dustinswales
-physics/gwdps.*                                @Songyou184                          @grantfirl @Qingfu-Liu @dustinswales
-physics/h2o_def.*                                                                   @grantfirl @Qingfu-Liu @dustinswales
-physics/h2ointerp.f90                                                               @grantfirl @Qingfu-Liu @dustinswales
-physics/h2ophys.*                              @Qingfu-Liu                          @grantfirl @Qingfu-Liu @dustinswales
-physics/hedmf.*                                @JongilHan66 @WeiguoWang-NOAA        @grantfirl @Qingfu-Liu @dustinswales
-physics/iccn_def.F                                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/iccninterp.F90                                                              @grantfirl @Qingfu-Liu @dustinswales
-physics/iounitdef.f                                                                 @grantfirl @Qingfu-Liu @dustinswales
-physics/lsm_noah.*                             @HelinWei-NOAA                       @grantfirl @Qingfu-Liu @dustinswales
-physics/lsm_ruc.*                              @tanyasmirnova                       @grantfirl @Qingfu-Liu @dustinswales
-physics/machine.*                                                                   @grantfirl @Qingfu-Liu @dustinswales
-physics/maximum_hourly_diagnostics.*                                                @grantfirl @Qingfu-Liu @dustinswales
-physics/mersenne_twister.f                                                          @grantfirl @Qingfu-Liu @dustinswales
-physics/mfpbl.f                                @JongilHan66                         @grantfirl @Qingfu-Liu @dustinswales
-physics/mfpblt.f                               @JongilHan66                         @grantfirl @Qingfu-Liu @dustinswales
-physics/mfpbltq.f                              @JongilHan66                         @grantfirl @Qingfu-Liu @dustinswales
-physics/mfscu.f                                @JongilHan66                         @grantfirl @Qingfu-Liu @dustinswales
-physics/mfscuq.f                               @JongilHan66                         @grantfirl @Qingfu-Liu @dustinswales
-physics/micro_mg*                              @AnningCheng-NOAA @andrewgettelman   @grantfirl @Qingfu-Liu @dustinswales
-physics/m_micro*                               @AnningCheng-NOAA @andrewgettelman   @grantfirl @Qingfu-Liu @dustinswales
-physics/module_bfmicrophysics.f                                                     @grantfirl @Qingfu-Liu @dustinswales
-physics/module_BL_MYJPBL.*                     @Qingfu-Liu                          @grantfirl @Qingfu-Liu @dustinswales
-physics/module_bl_mynn.*                       @joeolson42                          @grantfirl @Qingfu-Liu @dustinswales
-physics/module_gfdl_cloud_microphys.*          @RuiyuSun                            @grantfirl @Qingfu-Liu @dustinswales
-physics/module_MP_FER_HIRES.*                  @ericaligo-NOAA                      @grantfirl @Qingfu-Liu @dustinswales
-physics/module_mp_nssl_2mom.F90                @MicroTed                            @grantfirl @Qingfu-Liu @dustinswales
-physics/module_mp_radar.*                      @gthompsnWRF @RuiyuSun               @grantfirl @Qingfu-Liu @dustinswales
-physics/module_mp_thompson*                    @gthompsnWRF @RuiyuSun @AndersJensen-NOAA @grantfirl @Qingfu-Liu @dustinswales
-physics/module_nst*                            @XuLi-NOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/module_sf_exchcoef.f90                 @ZhanZhang-NOAA                      @grantfirl @Qingfu-Liu @dustinswales
-physics/module_SF_JSFC.F90                     @Qingfu-Liu                          @grantfirl @Qingfu-Liu @dustinswales
-physics/module_sf_mynn.F90                     @joeolson42                          @grantfirl @Qingfu-Liu @dustinswales
-physics/module_sf_ruclsm.*                     @tanyasmirnova                       @grantfirl @Qingfu-Liu @dustinswales
-physics/module_soil_pre.*                      @tanyasmirnova                       @grantfirl @Qingfu-Liu @dustinswales
-physics/moninshoc.*                                                                 @grantfirl @Qingfu-Liu @dustinswales
-physics/mp_fer_hires.*                         @ericaligo-NOAA                      @grantfirl @Qingfu-Liu @dustinswales
-physics/mp_nssl.*                              @MicroTed                            @grantfirl @Qingfu-Liu @dustinswales
-physics/mp_thompson*                           @gthompsnWRF @RuiyuSun @AndersJensen-NOAA @grantfirl @Qingfu-Liu @dustinswales
-physics/multi_gases.F90                        @RuiyuSun                            @grantfirl @Qingfu-Liu @dustinswales
-physics/myjpbl_wrapper.*                       @Qingfu-Liu                          @grantfirl @Qingfu-Liu @dustinswales
-physics/myjsfc_wrapper.*                       @Qingfu-Liu                          @grantfirl @Qingfu-Liu @dustinswales
-physics/mynnedmf_wrapper.*                     @joeolson42                          @grantfirl @Qingfu-Liu @dustinswales
-physics/mynnsfc_wrapper.*                      @joeolson42                          @grantfirl @Qingfu-Liu @dustinswales
-physics/namelist_soilveg.*                     @HelinWei-NOAA @barlage @cenlinhe    @grantfirl @Qingfu-Liu @dustinswales
-physics/namelist_soilveg_ruc.*                 @tanyasmirnova                       @grantfirl @Qingfu-Liu @dustinswales
-physics/*noahmp*                               @barlage @cenlinhe                   @grantfirl @Qingfu-Liu @dustinswales
-physics/ozinterp.f90                                                                @grantfirl @Qingfu-Liu @dustinswales
-physics/ozne_def.*                                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/ozphys*                                @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/physcons.F90                                                                @grantfirl @Qingfu-Liu @dustinswales
-physics/phys_tend.*                                                                 @grantfirl @Qingfu-Liu @dustinswales
-physics/progsigma_calc.f90                     @lisa-bengtsson                      @grantfirl @Qingfu-Liu @dustinswales
-physics/radcons.f90                            @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/radiation_aerosols.f                   @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/radiation_astronomy.f                  @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/radiation_cloud_overlap.F90            @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/radiation_clouds.f                     @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/radiation_gases.f                      @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/radiation_surface.*                    @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/radiation_tools.F90                    @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/radlw_*                                @mjiacono @Qingfu-Liu                @grantfirl @Qingfu-Liu @dustinswales
-physics/radsw_*                                @mjiacono @Qingfu-Liu                @grantfirl @Qingfu-Liu @dustinswales
-physics/rascnv.*                               @haiqinli @JongilHan66               @grantfirl @Qingfu-Liu @dustinswales
-physics/rayleigh_damp.*                        @yangfanglin                         @grantfirl @Qingfu-Liu @dustinswales
-physics/rrtmg_lw_cloud_optics.F90              @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/rrtmg_lw_post.*                        @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/rrtmg_lw_pre.*                         @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales
-physics/rrtmgp_aerosol_optics.*                @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/rrtmgp_lw_*                            @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/rrtmgp_sw_*                            @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/rrtmg_sw_cloud_optics.F90              @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/rrtmg_sw_post.*                        @Qingfu-Liu @dustinswales            @grantfirl @Qingfu-Liu @dustinswales 
-physics/rte-rrtmgp                             @dustinswales @Qingfu-Liu            @grantfirl @Qingfu-Liu @dustinswales
-physics/samfdeepcnv.*                          @JongilHan66 @lisa-bengtsson         @grantfirl @Qingfu-Liu @dustinswales
-physics/samfshalcnv.*                          @JongilHan66 @lisa-bengtsson         @grantfirl @Qingfu-Liu @dustinswales
-physics/samfaerosols.*                         @JongilHan66 @lisa-bengtsson         @grantfirl @Qingfu-Liu @dustinswales
-physics/sascnvn.*                              @JongilHan66                         @grantfirl @Qingfu-Liu @dustinswales
-physics/satmedmfvdif.*                         @JongilHan66                         @grantfirl @Qingfu-Liu @dustinswales
-physics/satmedmfvdifq.*                        @JongilHan66                         @grantfirl @Qingfu-Liu @dustinswales
-physics/scm_sfc_flux_spec.*                    @grantfirl                           @grantfirl @Qingfu-Liu @dustinswales
-physics/set_soilveg.*                          @HelinWei-NOAA @barlage @cenlinhe    @grantfirl @Qingfu-Liu @dustinswales
-physics/set_soilveg_ruc.*                      @tanyasmirnova                       @grantfirl @Qingfu-Liu @dustinswales
-physics/sfc_cice.*                             @wd20xw                              @grantfirl @Qingfu-Liu @dustinswales
-physics/sfc_diag.*                                                                  @grantfirl @Qingfu-Liu @dustinswales
-physics/sfc_diag_post.*                                                             @grantfirl @Qingfu-Liu @dustinswales
-physics/sfc_diff.*                             @JongilHan66                         @grantfirl @Qingfu-Liu @dustinswales
-physics/sfc_nst*                               @XuLi-NOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/sfc_ocean.*                            @HelinWei-NOAA                       @grantfirl @Qingfu-Liu @dustinswales
-physics/sfc_sice.*                             @wd20xw                              @grantfirl @Qingfu-Liu @dustinswales
-physics/sfcsub.F                                                                    @grantfirl @Qingfu-Liu @dustinswales
-physics/sflx.f                                 @HelinWei-NOAA                       @grantfirl @Qingfu-Liu @dustinswales
-physics/sgscloud_radpost.*                                                          @grantfirl @Qingfu-Liu @dustinswales
-physics/sgscloud_radpre.*                                                           @grantfirl @Qingfu-Liu @dustinswales
-physics/shalcnv.*                              @JongilHan66                         @grantfirl @Qingfu-Liu @dustinswales
-physics/shinhongvdif.*                         @Qingfu-Liu @WeiguoWang-NOAA         @grantfirl @Qingfu-Liu @dustinswales
-physics/shoc.*                                                                      @grantfirl @Qingfu-Liu @dustinswales
-physics/surface_perturbation.*                 @HelinWei-NOAA                       @grantfirl @Qingfu-Liu @dustinswales
-physics/tridi.f                                @JongilHan66 @WeiguoWang-NOAA        @grantfirl @Qingfu-Liu @dustinswales
-physics/ugwp_driver_v0.F                       @mdtoyNOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/ugwpv1_gsldrag.*                       @mdtoyNOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/ugwpv1_gsldrag_post.*                  @mdtoyNOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/unified_ugwp*                          @mdtoyNOAA                           @grantfirl @Qingfu-Liu @dustinswales
-physics/wv_saturation.F                        @AnningCheng-NOAA @andrewgettelman   @grantfirl @Qingfu-Liu @dustinswales
-physics/ysuvdif.*                              @Qingfu-Liu @WeiguoWang-NOAA         @grantfirl @Qingfu-Liu @dustinswales
-physics/zhaocarr_gscond.*                      @RuiyuSun                            @grantfirl @Qingfu-Liu @dustinswales
-physics/zhaocarr_precpd.*                      @RuiyuSun                            @grantfirl @Qingfu-Liu @dustinswales
-
-physics/sfc_land.*                             @uturuncoglu @barlage
+physics/CONV/C3/cu_c3*                                                       @lisa-bengtsson @haiqinli                 @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/Chikira_Sugiyama/cs_conv_aw_adj.*                               @AnningCheng-NOAA                         @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/Chikira_Sugiyama/cs_conv.*                                      @AnningCheng-NOAA                         @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/Grell_Freitas/cu_gf*                                            @haiqinli                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/RAS/rascnv.*                                                    @haiqinli @JongilHan66                    @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/SAMF/samfdeepcnv.*                                              @JongilHan66 @lisa-bengtsson              @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/SAMF/samfshalcnv.*                                              @JongilHan66 @lisa-bengtsson              @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/SAMF/samfaerosols.*                                             @JongilHan66 @lisa-bengtsson              @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/SAS/sascnvn.*                                                   @JongilHan66                              @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/SAS/shalcnv.*                                                   @JongilHan66                              @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/nTiedtke/cu_ntiedtke*                                           @JongilHan66 @Qingfu-Liu                  @grantfirl @Qingfu-Liu @dustinswales
+physics/CONV/progsigma_calc.f90                                              @lisa-bengtsson                           @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/cires_orowam2017.f                                               @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/cires_tauamf_data.F90                                            @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/cires_ugwp*                                                      @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/drag_suite.*                                                     @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/gwdc.*                                                           @Songyou184                               @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/gwdps.*                                                          @Songyou184                               @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/rayleigh_damp.*                                                  @yangfanglin                              @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/ugwp_driver_v0.F                                                 @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/ugwpv1_gsldrag.*                                                 @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/ugwpv1_gsldrag_post.*                                            @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/GWD/unified_ugwp*                                                    @mdtoyNOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Ferrier_Aligo/module_MP_FER_HIRES.*                               @ericaligo-NOAA                           @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Ferrier_Aligo/mp_fer_hires.*                                      @ericaligo-NOAA                           @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/GFDL/GFDL_parse_tracers.F90                                                                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/GFDL/gfdl_cloud_microphys.*                                       @RuiyuSun                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/GFDL/module_gfdl_cloud_microphys.*                                @RuiyuSun                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/GFDL/fv_sat_adj.*                                                 @RuiyuSun                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/GFDL/multi_gases.F90                                              @RuiyuSun                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Morrison_Gettelman/aer_cloud.F                                    @AnningCheng-NOAA @andrewgettelman        @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Morrison_Gettelman/aerclm_def.F                                   @AnningCheng-NOAA @andrewgettelman        @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Morrison_Gettelman/aerinterp.F90                                  @AnningCheng-NOAA @andrewgettelman        @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Morrison_Gettelman/cldmacro.F                                     @AnningCheng-NOAA @andrewgettelman        @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Morrison_Gettelman/cldwat2m_micro.F                               @AnningCheng-NOAA @andrewgettelman        @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Morrison_Gettelman/micro_mg*                                      @AnningCheng-NOAA @andrewgettelman        @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Morrison_Gettelman/m_micro*                                       @AnningCheng-NOAA @andrewgettelman        @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Morrison_Gettelman/wv_saturation.F                                @AnningCheng-NOAA @andrewgettelman        @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/NSSL/module_mp_nssl_2mom.F90                                      @MicroTed                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/NSSL/mp_nssl.*                                                    @MicroTed                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Thompson/module_mp_thompson*                                      @gthompsnWRF @RuiyuSun @AndersJensen-NOAA @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Thompson/mp_thompson*                                             @gthompsnWRF @RuiyuSun @AndersJensen-NOAA @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Zhao_Carr/zhaocarr_gscond.*                                       @RuiyuSun                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/Zhao_Carr/zhaocarr_precpd.*                                       @RuiyuSun                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/calpreciptype.f90                                                                                           @grantfirl @Qingfu-Liu @dustinswales
+physics/MP/module_mp_radar.*                                                 @gthompsnWRF @RuiyuSun                    @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/HEDMF/hedmf.*                                                    @JongilHan66 @WeiguoWang-NOAA             @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/MYJ/module_BL_MYJPBL.*                                           @Qingfu-Liu                               @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/MYJ/myjpbl_wrapper.*                                             @Qingfu-Liu                               @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/MYNN_EDMF/bl_mynn_common.f90                                     @joeolson42                               @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/MYNN_EDMF/module_bl_mynn.*                                       @joeolson42                               @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/MYNN_EDMF/mynnedmf_wrapper.*                                     @joeolson42                               @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/SATMEDMF/satmedmfvdif.*                                          @JongilHan66                              @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/SATMEDMF/satmedmfvdifq.*                                         @JongilHan66                              @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/SATMEDMF/mfscu.f                                                 @JongilHan66                              @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/SATMEDMF/mfscuq.f                                                @JongilHan66                              @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/SHOC/moninshoc.*                                                                                           @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/SHOC/shoc.*                                                                                                @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/YSU/ysuvdif.*                                                    @Qingfu-Liu @WeiguoWang-NOAA              @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/saYSU/shinhongvdif.*                                             @Qingfu-Liu @WeiguoWang-NOAA              @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/mfpbl.f                                                          @JongilHan66                              @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/mfpblt.f                                                         @JongilHan66                              @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/mfpbltq.f                                                        @JongilHan66                              @grantfirl @Qingfu-Liu @dustinswales
+physics/PBL/tridi.f                                                          @JongilHan66 @WeiguoWang-NOAA             @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMG/iounitdef.f                                                                                    @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMG/module_bfmicrophysics.f                                                                        @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMG/rad_sw_pre*                                          @mjiacono @Qingfu-Liu                     @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMG/radcons.f90                                          @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMG/radlw_*                                              @mjiacono @Qingfu-Liu                     @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMG/radsw_*                                              @mjiacono @Qingfu-Liu                     @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMG/rrtmg_lw_cloud_optics.F90                            @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMG/rrtmg_lw_post.*                                      @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMG/rrtmg_sw_cloud_optics.F90                            @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMG/rrtmg_sw_post.*                                      @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMGP/rte-rrtmgp                                          @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMGP/rrtmgp_aerosol_optics.*                             @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMGP/rrtmgp_lw_*                                         @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/RRTMGP/rrtmgp_sw_*                                         @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/mersenne_twister.f                                                                                   @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/radiation_aerosols.f                                       @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/radiation_astronomy.f                                      @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/radiation_cloud_overlap.F90                                @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/radiation_clouds.f                                         @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/radiation_gases.f                                          @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/radiation_surface.f                                        @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Radiation/radiation_tools.F90                                        @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/GFDL/gfdl_sfc_layer.*                                      @ZhanZhang-NOAA                           @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/GFDL/module_sf_exchcoef.f90                                @ZhanZhang-NOAA                           @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/MYJ/myjsfc_wrapper.*                                       @Qingfu-Liu                               @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/MYJ/module_SF_JSFC.F90                                     @Qingfu-Liu                               @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/MYNN/mynnsfc_wrapper.*                                     @joeolson42                               @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/MYNN/module_sf_mynn.F90                                    @joeolson42                               @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/UFS/date_def.f                                             @XuLi-NOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/UFS/module_nst*                                            @XuLi-NOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/UFS/sfc_diag.*                                                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/UFS/sfc_diag_post.*                                                                                  @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/UFS/sfc_diff.*                                             @JongilHan66                              @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Layer/UFS/sfc_nst*                                               @XuLi-NOAA                                @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Lake/CLM/clm_lake.*                                       @tanyasmirnova @SamuelTrahanNOAA          @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Lake/Flake/flake*                                         @barlage                                  @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/Noah/lsm_noah.*                                      @HelinWei-NOAA                            @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/Noah/namelist_soilveg.*                              @HelinWei-NOAA @barlage @cenlinhe         @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/Noah/set_soilveg.*                                   @HelinWei-NOAA @barlage @cenlinhe         @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/Noah/sflx.f                                          @HelinWei-NOAA                            @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/Noah/surface_perturbation.*                          @HelinWei-NOAA                            @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/Noahmp/*noahmp*                                      @barlage @cenlinhe                        @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/RUC/lsm_ruc.*                                        @tanyasmirnova                            @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/RUC/module_sf_ruclsm.*                               @tanyasmirnova                            @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/RUC/module_soil_pre.*                                @tanyasmirnova                            @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/RUC/namelist_soilveg_ruc.*                           @tanyasmirnova                            @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/RUC/set_soilveg_ruc.*                                @tanyasmirnova                            @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Land/sfc_land.*                                                                                     @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/Ocean/UFS/sfc_ocean.*                                     @HelinWei-NOAA                            @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/SeaIce/CICE/sfc_cice.*                                    @wd20xw                                   @grantfirl @Qingfu-Liu @dustinswales
+physics/SFC_Models/SeaIce/CICE/sfc_sice.*                                    @wd20xw                                   @grantfirl @Qingfu-Liu @dustinswales
+physics/hooks/machine.*                                                                                                @grantfirl @Qingfu-Liu @dustinswales
+physics/hooks/physcons.F90                                                                                             @grantfirl @Qingfu-Liu @dustinswales
+physics/photochem/h2o_def.*                                                                                            @grantfirl @Qingfu-Liu @dustinswales
+physics/photochem/h2ointerp.f90                                                                                        @grantfirl @Qingfu-Liu @dustinswales
+physics/photochem/h2ophys.*                                                  @Qingfu-Liu                               @grantfirl @Qingfu-Liu @dustinswales
+physics/photochem/module_ozphys.*                                            @dustinswales                             @grantfirl @Qingfu-Liu @dustinswales
+physics/smoke_dust/*                                                         @haiqinli                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/tools/funcphys.f90                                                                                             @grantfirl @Qingfu-Liu @dustinswales
+physics/tools/get_phi_fv3.*                                                                                            @grantfirl @Qingfu-Liu @dustinswales
+physics/tools/get_prs_fv3.*                                                                                            @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_cloud_diagnostics.*                @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_DCNV_generic_post.*                                                          @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_DCNV_generic_pre.*                                                           @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_debug.*                                                                      @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_GWD_generic_post.*                                                           @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_GWD_generic_pre.*                                                            @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.*                                                            @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_pre.*                                                             @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_PBL_generic_common.F90                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_PBL_generic_post.*                                                           @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_PBL_generic_pre.*                                                            @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.*                                                         @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.scm.*                                                         @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_physics_post.*                                                               @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_radiation_surface.*                                                          @grantfirl @Qingfu-Liu @dustinswales 
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.fv3.*                                                          @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.scm.*                                                          @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_mp.*                  @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_overlap.*             @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_post.*                       @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_pre.*                       @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_pre.*                        @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_setup.*                     @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_post.*                      @dustinswales @Qingfu-Liu                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_setup.*                      @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_SCNV_generic_post.*                                                          @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_SCNV_generic_pre.*                                                           @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_stochastics.*                      @pjpegion @lisa-bengtsson                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_1.*                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_2.*                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_3.*                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_4.*                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_5.*                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_phys_reset.*                                              @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_rad_reset.*                                               @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_stateout_reset.*                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_stateout_update.*                                                      @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_inter.*                                                   @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.*                                                    @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.*                                                     @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_post.*                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.*                                                        @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part1.*                                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_loop_control_part2.*                                                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.fv3.*                                                          @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.scm.*                                                          @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/cnvc90.*                                                                         @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.*                              @Qingfu-Liu @dustinswales                 @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/gcycle.F90                                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/iccn_def.F                                                                       @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/iccninterp.F90                                                                   @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/maximum_hourly_diagnostics.*                                                     @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/scm_sfc_flux_spec.*                    @grantfirl                                @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F                                                                         @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/sgscloud_radpost.*                                                               @grantfirl @Qingfu-Liu @dustinswales
+physics/Interstitials/UFS_SCM_NEPTUNE/sgscloud_radpre.*                                                                @grantfirl @Qingfu-Liu @dustinswales
 
 ########################################################################
 

--- a/physics/CONV/Grell_Freitas/cu_gf_deep.F90
+++ b/physics/CONV/Grell_Freitas/cu_gf_deep.F90
@@ -316,7 +316,7 @@ contains
      real(kind=kind_phys), dimension (its:ite,kts:kte) :: pwdper, massflx
      integer :: nv
 !$acc declare create(chem,chem_cup,chem_up,chem_down,dellac,dellac2,chem_c,chem_pw,chem_pwd,   &
-!$acc                         chem_pwav,chem_psum,pwdper,massflux)
+!$acc                         chem_pwav,chem_psum,pwdper,massflx)
 
      real(kind=kind_phys),    dimension (its:ite,kts:kte) ::            &
         entr_rate_2d,mentrd_rate_2d,he,hes,qes,z, heo,heso,qeso,zo,     &                    

--- a/physics/GWD/gwdps.meta
+++ b/physics/GWD/gwdps.meta
@@ -373,7 +373,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = inout
 [ldiag_ugwp]
   standard_name = flag_for_unified_gravity_wave_physics_diagnostics
   long_name = flag for CIRES UGWP Diagnostics

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_DCNV_generic_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_DCNV_generic_pre.meta
@@ -126,7 +126,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.F90
@@ -43,10 +43,10 @@
       integer, intent(in) :: index_of_temperature,index_of_process_mp,use_lake_model(:)
       integer, intent(in) :: imfshalcnv,imfshalcnv_gf,imfdeepcnv,imfdeepcnv_gf,imfdeepcnv_samf
       integer, dimension (:), intent(in) :: htop
-      integer                                                :: dfi_radar_max_intervals
+      integer,                                 intent(in)    :: dfi_radar_max_intervals
       real(kind=kind_phys),                    intent(in)    :: fh_dfi_radar(:), fhour, con_t0c
       real(kind=kind_phys),                    intent(in)    :: radar_tten_limits(:)
-      integer                                                :: ix_dfi_radar(:)
+      integer,                                 intent(in)    :: ix_dfi_radar(:)
       real(kind=kind_phys), dimension(:,:),    intent(inout) :: gt0,refl_10cm
 
       real(kind=kind_phys),                    intent(in)    :: dtf, frain, con_g, rainmin, rhowater

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.F90
@@ -27,7 +27,7 @@
         totprcp, totice, totsnw, totgrp, cnvprcpb, totprcpb, toticeb, totsnwb, totgrpb, rain_cpl, rainc_cpl, snow_cpl,    &
         pwat, frzr, frzrb, frozr, frozrb, tsnowp, tsnowpb, rhonewsn1, exticeden,                                          & 
         drain_cpl, dsnow_cpl, lsm, lsm_ruc, lsm_noahmp, raincprv, rainncprv, iceprv, snowprv,                             &
-        graupelprv, draincprv, drainncprv, diceprv, dsnowprv, dgraupelprv, dtp, dfi_radar_max_intervals,                  &
+        graupelprv, draincprv, drainncprv, diceprv, dsnowprv, dgraupelprv, dtp,                                           &
         dtend, dtidx, index_of_temperature, index_of_process_mp,ldiag3d, qdiag3d,dqdt_qmicro, lssav, num_dfi_radar,       &
         fh_dfi_radar,index_of_process_dfi_radar, ix_dfi_radar, dfi_radar_tten, radar_tten_limits, fhour, prevsq,      &
         iopt_lake, iopt_lake_clm, lkm, use_lake_model, errmsg, errflg)
@@ -43,7 +43,6 @@
       integer, intent(in) :: index_of_temperature,index_of_process_mp,use_lake_model(:)
       integer, intent(in) :: imfshalcnv,imfshalcnv_gf,imfdeepcnv,imfdeepcnv_gf,imfdeepcnv_samf
       integer, dimension (:), intent(in) :: htop
-      integer,                                 intent(in)    :: dfi_radar_max_intervals
       real(kind=kind_phys),                    intent(in)    :: fh_dfi_radar(:), fhour, con_t0c
       real(kind=kind_phys),                    intent(in)    :: radar_tten_limits(:)
       integer,                                 intent(in)    :: ix_dfi_radar(:)

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
@@ -229,7 +229,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [prsl]
   standard_name = air_pressure
   long_name = layer mean pressure

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
@@ -229,7 +229,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [prsl]
   standard_name = air_pressure
   long_name = layer mean pressure
@@ -430,7 +430,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_tracers)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [rain0]
   standard_name = lwe_thickness_of_explicit_rain_amount
   long_name = explicit rain on physics timestep

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_MP_generic_post.meta
@@ -772,13 +772,6 @@
   type = real
   kind = kind_phys
   intent = in
-[dfi_radar_max_intervals]
-  standard_name = maximum_number_of_radar_derived_temperature_or_convection_suppression_intervals
-  long_name = maximum allowed number of time ranges with radar-derived microphysics temperature tendencies or radar-derived convection suppression
-  units = count
-  dimensions = ()
-  type = integer
-  intent = in
 [num_dfi_radar]
   standard_name = number_of_radar_derived_temperature_or_convection_suppression_intervals
   long_name = number of time ranges with radar-derived microphysics temperature tendencies or radar-derived convection suppression

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.F90
@@ -41,7 +41,7 @@ contains
       logical,                              intent(in) :: cplflx, frac_grid, cplwav2atm, frac_ice
       logical,                              intent(in) :: lheatstrg
       logical, dimension(:),                intent(in) :: flag_cice, dry, icy
-      logical, dimension(:),             intent(inout) :: wet
+      logical, dimension(:),                intent(in) :: wet
       integer, dimension(:),                intent(in) :: islmsk, use_lake_model
       real(kind=kind_phys), dimension(:),   intent(in) :: wind, t1, q1, prsl1, landfrac, lakefrac, oceanfrac,                   &
         cd_wat, cd_lnd, cd_ice, cdq_wat, cdq_lnd, cdq_ice, rb_wat, rb_lnd, rb_ice, stress_wat,                                  &

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
@@ -7670,7 +7670,7 @@ cjfe
                   ! points.  so for efficiency, don't have fixrdc try to
                   ! find a value at landice points as defined by the vet type (vet).
               allocate(slmask_noice(len))
-              slmask_noice = 1.0
+              slmask_noice = slmskl
               do i = 1, len
                 if (nint(vet(i)) < 1 .or.
      &              nint(vet(i)) == landice_cat) then

--- a/physics/PBL/MYNN_EDMF/mynnedmf_wrapper.F90
+++ b/physics/PBL/MYNN_EDMF/mynnedmf_wrapper.F90
@@ -172,7 +172,7 @@ SUBROUTINE mynnedmf_wrapper_run(        &
      implicit none
 !------------------------------------------------------------------- 
 
-     real(kind_phys)               :: huge
+     real(kind_phys),  intent(in)  :: huge
      character(len=*), intent(out) :: errmsg
      integer, intent(out)          :: errflg
 
@@ -290,7 +290,7 @@ SUBROUTINE mynnedmf_wrapper_run(        &
       real(kind_phys), dimension(:), intent(inout) :: frp
       logical, intent(in) :: mix_chem, enh_mix, rrfs_sd
       real(kind_phys), dimension(:,:,:), intent(inout) :: chem3d
-      real(kind_phys), dimension(:,:  ), intent(inout) :: vdep
+      real(kind_phys), dimension(:,:  ), intent(in) :: vdep
       real(kind_phys), dimension(im)   :: emis_ant_no
 
 !MYNN-2D

--- a/physics/PBL/SATMEDMF/satmedmfvdif.meta
+++ b/physics/PBL/SATMEDMF/satmedmfvdif.meta
@@ -503,7 +503,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/PBL/SATMEDMF/satmedmfvdifq.meta
+++ b/physics/PBL/SATMEDMF/satmedmfvdifq.meta
@@ -625,7 +625,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/PBL/SHOC/moninshoc.meta
+++ b/physics/PBL/SHOC/moninshoc.meta
@@ -456,7 +456,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/PBL/YSU/ysuvdif.meta
+++ b/physics/PBL/YSU/ysuvdif.meta
@@ -466,7 +466,7 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension,cumulative_change_of_state_variables_outer_index_max)
   type = real
   kind = kind_phys
-  intent = in
+  intent = inout
 [dtidx]
   standard_name = cumulative_change_of_state_variables_outer_index
   long_name = index of state-variable and process in last dimension of diagnostic tendencies array AKA cumulative_change_index

--- a/physics/SFC_Layer/UFS/sfc_diag.meta
+++ b/physics/SFC_Layer/UFS/sfc_diag.meta
@@ -218,7 +218,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = inout
+  intent = in
 [tskin]
   standard_name = surface_skin_temperature
   long_name = surface skin temperature
@@ -314,7 +314,7 @@
   long_name = model 2m diagnostics use the temperature and humidity calculated by the lake model
   units = flag
   dimensions = ()
-  type = integer
+  type = logical
   intent = in
 [wind]
   standard_name = wind_speed_at_lowest_model_layer

--- a/physics/SFC_Layer/UFS/sfc_diag_post.F90
+++ b/physics/SFC_Layer/UFS/sfc_diag_post.F90
@@ -28,7 +28,7 @@
         logical             , dimension(:),  intent(in) :: dry
         real(kind=kind_phys), dimension(:),  intent(in) :: pgr, u10m, v10m
         real(kind=kind_phys), dimension(:),  intent(inout) :: t2m, q2m, tmpmin, tmpmax, spfhmin, spfhmax
-        real(kind=kind_phys), dimension(:),  intent(inout) :: t2mmp, q2mp
+        real(kind=kind_phys), dimension(:),  intent(in)    :: t2mmp, q2mp
         real(kind=kind_phys), dimension(:),  intent(inout) :: wind10mmax, u10mmax, v10mmax, dpt2m
 
         character(len=*),                     intent(out) :: errmsg

--- a/physics/SFC_Layer/UFS/sfc_diag_post.meta
+++ b/physics/SFC_Layer/UFS/sfc_diag_post.meta
@@ -96,7 +96,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [q2mp]
   standard_name = specific_humidity_at_2m_from_noahmp
   long_name = 2 meter specific humidity from noahmp
@@ -104,7 +104,7 @@
   dimensions = (horizontal_loop_extent)
   type = real
   kind = kind_phys
-  intent = out
+  intent = in
 [t2m]
   standard_name = air_temperature_at_2m
   long_name = 2 meter temperature

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90
@@ -449,7 +449,7 @@ contains
 		   ghb     , irg     , irc     , irb     , tr      , evc     , & ! out :
 		   chleaf  , chuc    , chv2    , chb2    , fpice   , pahv    , &
                    pahg    , pahb    , pah     , esnow   , canhs   , laisun  , &
-                   laisha  , laisune , laishae , rb      , qsfcveg , qsfcbare  &
+                   laisha  , rb      , qsfcveg , qsfcbare                      &
 #ifdef CCPP
                    ,errmsg, errflg)
 #else
@@ -594,8 +594,6 @@ contains
   real (kind=kind_phys)                           , intent(out)   :: rb        !< leaf boundary layer resistance (s/m)
   real (kind=kind_phys)                           , intent(out)   :: laisun    !< sunlit leaf area index (m2/m2)
   real (kind=kind_phys)                           , intent(out)   :: laisha    !< shaded leaf area index (m2/m2)
-  real (kind=kind_phys)                           , intent(out)   :: laisune   !< sunlit leaf area index, one-sided (m2/m2),effective
-  real (kind=kind_phys)                           , intent(out)   :: laishae   !< shaded leaf area index, one-sided (m2/m2),effective
   real (kind=kind_phys)                           , intent(out)   :: qsfcveg   !< effective spec humid over vegetation 
   real (kind=kind_phys)                           , intent(out)   :: qsfcbare  !< effective spec humid over bare soil 
 
@@ -844,10 +842,11 @@ contains
                  tv     ,tg     ,stc    ,snowh  ,eah    ,tah    , & !inout
                  sneqvo ,sneqv  ,sh2o   ,smc    ,snice  ,snliq  , & !inout
                  albold ,cm     ,ch     ,dx     ,dz8w   ,q2     , & !inout
-                 ustarx ,tauss  ,                                 & !inout
-                 laisun ,laisha ,laisune, laishae, rb   ,         & !out
+                 ustarx ,                                         & !inout
 #ifdef CCPP
-                 errmsg ,errflg ,    & !out
+                 tauss  ,laisun ,laisha ,rb , errmsg ,errflg ,    & !inout
+#else
+                 tauss  ,laisun ,laisha ,rb ,                     & !inout
 #endif
 !jref:start
                  qc     ,qsfc   ,psfc   , & !in 
@@ -1687,10 +1686,11 @@ endif   ! croptype == 0
                      tv     ,tg     ,stc    ,snowh  ,eah    ,tah    , & !inout
                      sneqvo ,sneqv  ,sh2o   ,smc    ,snice  ,snliq  , & !inout
                      albold ,cm     ,ch     ,dx     ,dz8w   ,q2     , &   !inout
-                     ustarx ,tauss  ,                                 &   !inout
-                     laisun ,laisha ,laisune,laishae,rb     ,         & !out
+                     ustarx ,                                         &   !inout
 #ifdef CCPP
-                     errmsg ,errflg,                                  & !out
+                     tauss  ,laisun ,laisha ,rb ,errmsg ,errflg,      & !inout
+#else
+                     tauss  ,laisun ,laisha ,rb ,                     & !inout
 #endif
 !jref:start
                      qc     ,qsfc   ,psfc   , & !in 
@@ -1879,11 +1879,9 @@ endif   ! croptype == 0
   real (kind=kind_phys)                              , intent(inout) :: ch     !< sensible heat exchange coefficient
   real (kind=kind_phys)                              , intent(inout) :: q1     !< 
   real (kind=kind_phys)                              , intent(inout) :: ustarx !< friction velocity
-  real (kind=kind_phys)                              , intent(  out) :: rb     !< leaf boundary layer resistance (s/m)
-  real (kind=kind_phys)                              , intent(  out) :: laisun !< sunlit leaf area index (m2/m2)
-  real (kind=kind_phys)                              , intent(  out) :: laisha !< shaded leaf area index (m2/m2)
-  real (kind=kind_phys)                              , intent(  out) :: laisune!< sunlit leaf area index, one-sided (m2/m2),effective
-  real (kind=kind_phys)                              , intent(  out) :: laishae!< shaded leaf area index, one-sided (m2/m2),effective
+  real (kind=kind_phys)                              , intent(inout) :: rb     !< leaf boundary layer resistance (s/m)
+  real (kind=kind_phys)                              , intent(inout) :: laisun !< sunlit leaf area index (m2/m2)
+  real (kind=kind_phys)                              , intent(inout) :: laisha !< shaded leaf area index (m2/m2)
 #ifdef CCPP
   character(len=*)                  , intent(inout) :: errmsg
   integer                           , intent(inout) :: errflg
@@ -2017,8 +2015,6 @@ endif   ! croptype == 0
     rb        = 0.
     laisun    = 0.
     laisha    = 0.
-    laisune   = 0.
-    laishae   = 0.
 
     cdmnv     = 0.0
     ezpdv     = 0.0
@@ -2269,8 +2265,8 @@ endif   ! croptype == 0
                     csigmaf1,                                     & !out
 !jref:start
                     qc      ,qsfc    ,psfc    , & !in
-                    q2v     ,chv2    ,chleaf  , chuc   ,          & !inout
-                    rb      ,laisune ,laishae )                     !out 
+                    q2v     ,chv2    ,chleaf  ,chuc    ,          &
+                    rb)                                             !out 
 
 ! new coupling code
 
@@ -3719,8 +3715,8 @@ endif   ! croptype == 0
                        t2mv    ,psnsun  ,psnsha  ,canhs   ,          & !out
                        csigmaf1,                                     & !out
                        qc      ,qsfc    ,psfc    ,                   & !in
-                       q2v     ,cah2    ,chleaf  ,chuc,              & !inout   
-                       rb      ,laisune ,laishae)                      !out 
+                       q2v     ,cah2    ,chleaf  ,chuc    ,          & !inout
+                       rb)                                             !out      
 
 ! --------------------------------------------------------------------------------------------------
 ! use newton-raphson iteration to solve for vegetation (tv) and
@@ -3845,8 +3841,6 @@ endif   ! croptype == 0
   real (kind=kind_phys),                           intent(out) :: canhs  !< canopy heat storage change (w/m2)
   real (kind=kind_phys),                           intent(out) :: q2v    !< 
   real (kind=kind_phys),                           intent(out) :: rb     !< bulk leaf boundary layer resistance (s/m)
-  real (kind=kind_phys),                           intent(out) :: laisune!< sunlit leaf area index, one-sided (m2/m2),effective
-  real (kind=kind_phys),                           intent(out) :: laishae!< shaded leaf area index, one-sided (m2/m2),effective
   real (kind=kind_phys) :: cah     !< sensible heat conductance, canopy air to zlvl air (m/s)
   real (kind=kind_phys) :: u10v    !< 10 m wind speed in eastward dir (m/s) 
   real (kind=kind_phys) :: v10v    !< 10 m wind speed in eastward dir (m/s) 
@@ -3942,6 +3936,8 @@ endif   ! croptype == 0
   real (kind=kind_phys) :: hcv          !canopy heat capacity j/m2/k, C.He added 
 
   real (kind=kind_phys) :: vaie         !total leaf area index + stem area index,effective
+  real (kind=kind_phys) :: laisune      !sunlit leaf area index, one-sided (m2/m2),effective
+  real (kind=kind_phys) :: laishae      !shaded leaf area index, one-sided (m2/m2),effective
 
   integer :: k         !index
   integer :: iter      !iteration index

--- a/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
+++ b/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
@@ -1063,14 +1063,14 @@
       zorl      (i)   = z0_total * 100.0  ! convert to cm
       ztmax     (i)   = z0h_total 
       
-      ! total stomatal/canopy resistance Based on Bonan et al. (2011) conductance (1/Rs) equation
+      !LAI-scale canopy resistance based on weighted sunlit shaded fraction
       if(rs_sunlit .le. 0.0 .or. rs_shaded .le. 0.0 .or. &
           lai_sunlit .eq. 0.0 .or. lai_shaded .eq. 0.0) then
-        rca(i) = 0.0
-      else
+        rca(i) = parameters%rsmax
+      else !calculate LAI-scale canopy conductance (1/Rs)
         rca(i) = ((1.0/(rs_sunlit+leaf_air_resistance)*lai_sunlit) + &
                  ((1.0/(rs_shaded+leaf_air_resistance))*lai_shaded))
-        rca(i) = 1.0/rca(i) !resistance
+        rca(i) = max((1.0/rca(i)),parameters%rsmin) !resistance
       end if
       
       smc       (i,:) = soil_moisture_vol

--- a/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
+++ b/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
@@ -620,8 +620,6 @@
   real (kind=kind_phys)                            :: snow_sublimation      !   out | snow sublimation [W/m2]
   real (kind=kind_phys)                            :: lai_sunlit            !   out | sunlit leaf area index [m2/m2]
   real (kind=kind_phys)                            :: lai_shaded            !   out | shaded leaf area index [m2/m2]
-  real (kind=kind_phys)                            :: lai_sunlit_eff        !   out | sunlit leaf area index, one-sided, effective [m2/m2]
-  real (kind=kind_phys)                            :: lai_shaded_eff        !   out | shaded leaf area index, one-sided, effective [m2/m2]
   real (kind=kind_phys)                            :: leaf_air_resistance   !   out | leaf boundary layer resistance [s/m]
 
   real (kind=kind_phys)                            :: canopy_heat_storage   !   out | within-canopy heat [W/m2]
@@ -1017,8 +1015,7 @@
           ch_vegetated_2m       ,ch_bare_ground_2m     ,precip_frozen_frac    , &
           precip_adv_heat_veg   ,precip_adv_heat_grd_v ,precip_adv_heat_grd_b , &
           precip_adv_heat_total ,snow_sublimation      ,canopy_heat_storage   , &
-          lai_sunlit            ,lai_shaded            ,lai_sunlit_eff        , &
-          lai_shaded_eff        ,leaf_air_resistance   ,                        &
+          lai_sunlit            ,lai_shaded            ,leaf_air_resistance   , &
 #ifdef CCPP
           spec_humid_sfc_veg    ,spec_humid_sfc_bare   ,                        &
           errmsg                ,errflg                )
@@ -1064,11 +1061,11 @@
       
       ! total stomatal/canopy resistance Based on Bonan et al. (2011) conductance (1/Rs) equation
       if(rs_sunlit .le. 0.0 .or. rs_shaded .le. 0.0 .or. &
-          lai_sunlit_eff .eq. 0.0 .or. lai_shaded_eff .eq. 0.0) then
+          lai_sunlit .eq. 0.0 .or. lai_shaded .eq. 0.0) then
         rca(i) = 0.0
       else
-        rca(i) = ((1.0/(rs_sunlit+leaf_air_resistance)*lai_sunlit_eff) + &
-                 ((1.0/(rs_shaded+leaf_air_resistance))*lai_shaded_eff))
+        rca(i) = ((1.0/(rs_sunlit+leaf_air_resistance)*lai_sunlit) + &
+                 ((1.0/(rs_shaded+leaf_air_resistance))*lai_shaded))
         rca(i) = 1.0/rca(i) !resistance
       end if
       

--- a/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
+++ b/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
@@ -157,7 +157,7 @@
       sncovr1, qsurf, gflux, drain, evap, hflx, ep, runoff,      &
       cmm, chh, evbs, evcw, sbsno, pah, ecan, etran, edir, snowc,&
       stm, snohf,smcwlt2, smcref2, wet1, t2mmp, q2mp,zvfun,      &
-      ztmax, errmsg, errflg,                                     &
+      ztmax, rca, errmsg, errflg,                                &
       canopy_heat_storage_ccpp,                                  &
       rainfall_ccpp,                                             &
       sw_absorbed_total_ccpp,                                    &
@@ -400,6 +400,8 @@
   real(kind=kind_phys), dimension(:)     , intent(out)   :: q2mp       ! combined q2m from tiles
   real(kind=kind_phys), dimension(:)     , intent(out)   :: zvfun      ! 
   real(kind=kind_phys), dimension(:)     , intent(out)   :: ztmax      ! thermal roughness length
+  real(kind=kind_phys), dimension(:)     , intent(out)   :: rca        ! total canopy/stomatal resistance (s/m)
+
   character(len=*)    ,                    intent(out)   :: errmsg
   integer             ,                    intent(out)   :: errflg
 
@@ -623,6 +625,8 @@
   real (kind=kind_phys)                            :: canopy_heat_storage   !   out | within-canopy heat [W/m2]
   real (kind=kind_phys)                            :: spec_humid_sfc_veg    !   out | surface specific humidty over vegetation [kg/kg]
   real (kind=kind_phys)                            :: spec_humid_sfc_bare   !   out | surface specific humidty over bare soil [kg/kg]
+  
+  real (kind=kind_phys)                            :: canopy_resistance     !   out | total canopy/stomatal resistance (s/m) 
 
   real (kind=kind_phys)                            :: ustarx                !  inout |surface friction velocity
   real (kind=kind_phys)                            :: prslkix               !  in exner function
@@ -1015,10 +1019,10 @@
           precip_adv_heat_total ,snow_sublimation      ,canopy_heat_storage   , &
           lai_sunlit            ,lai_shaded            ,leaf_air_resistance   , &
 #ifdef CCPP
-          spec_humid_sfc_veg    ,spec_humid_sfc_bare   ,                        &
+          spec_humid_sfc_veg    ,spec_humid_sfc_bare   ,canopy_resistance     , &
           errmsg                ,errflg                )
 #else
-          spec_humid_sfc_veg    ,spec_humid_sfc_bare   )
+          spec_humid_sfc_veg    ,spec_humid_sfc_bare   ,canopy_resistance     )
 #endif
         
 #ifdef CCPP
@@ -1056,7 +1060,7 @@
       chxy      (i)   = ch_noahmp
       zorl      (i)   = z0_total * 100.0  ! convert to cm
       ztmax     (i)   = z0h_total 
-
+      rca       (i)   = canopy_resistance
       smc       (i,:) = soil_moisture_vol
       slc       (i,:) = soil_liquid_vol
       snowxy    (i)   = float(snow_levels)

--- a/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
+++ b/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
@@ -950,6 +950,10 @@
         ch_vegetated           = 0.0
         ch_bare_ground         = ch_noahmp
         canopy_heat_storage    = 0.0
+        lai_sunlit             = 0.0
+        lai_shaded             = 0.0
+        rs_sunlit              = 0.0
+        rs_shaded              = 0.0
 
       else  ! not glacier
 

--- a/physics/SFC_Models/Land/Noahmp/noahmpdrv.meta
+++ b/physics/SFC_Models/Land/Noahmp/noahmpdrv.meta
@@ -1360,6 +1360,14 @@
   type = real
   kind = kind_phys
   intent = out
+[rca]
+  standard_name = aerodynamic_resistance_in_canopy
+  long_name = canopy resistance
+  units = s m-1
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
 [errmsg]
   standard_name = ccpp_error_message
   long_name = error message for error handling in CCPP

--- a/physics/photochem/module_ozphys.F90
+++ b/physics/photochem/module_ozphys.F90
@@ -306,8 +306,8 @@ contains
 
        ! Diagnostics (optional)
        if (do_diag) then
-          do3_dt_prd(:,iLev)  = (prod(:,1)-prod(:,2)*prod(:,6))*dt
-          do3_dt_ozmx(:,iLev) = (oz(:,iLev) - ozib(:))
+          do3_dt_prd(:,iLev)  = prod(:,1) * dt
+          do3_dt_ozmx(:,iLev) = prod(:,2) * (oz(:,iLev) - prod(:,6)) * dt
           do3_dt_temp(:,iLev) = prod(:,3)*(t(:,iLev)-prod(:,5))*dt
           do3_dt_ohoz(:,iLev) = prod(:,4) * (colo3(:,iLev)-coloz(:,iLev))*dt
        endif


### PR DESCRIPTION
This PR combines the following:

https://github.com/ufs-community/ccpp-physics/pull/196 (credit @DWesl) Note: changes baselines for tests that use `diag_additional_control_dtend` or `diag_additional_rap_dtend` diag tables: control_diag_debug_intel/gnu, rap_diag_debug_intel/gnu
https://github.com/ufs-community/ccpp-physics/pull/201 (credit @dustinswales)
https://github.com/ufs-community/ccpp-physics/pull/202 (credit @GeorgeGayno-NOAA)
https://github.com/ufs-community/ccpp-physics/pull/204 (credit @drnimbusrain)

Also, there are a couple of other bugfixes:
 - an updated CODEOWNERS file to update source file paths for automatically requesting reviews and to add a new person
 - a bug (openACC directive typo) was fixed in cu_gf_deep.F90 to fix failing NVidia compiler CI tests in the CCPP-SCM
