### PR TITLE
Add the TEMPO microphysics submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
   path = physics/Radiation/RRTMGP/rte-rrtmgp
   url = https://github.com/earth-system-radiation/rte-rrtmgp
   branch = main
+[submodule "physics/MP/TEMPO"]
+	path = physics/MP/TEMPO
+	url = https://github.com/NCAR/TEMPO.git


### PR DESCRIPTION
Development of the Thompson-Eidhammer microphysics is transitioning to a submodule, and this submodule is: https://github.com/NCAR/TEMPO

TEMPO stand for Thompson-Eidhammer Microphysics Parameterization for Operations.

The use of a submodule will enable centralized community development (and testing) of the microphysics scheme for various applications and dynamical cores. This submodule will eventually replace the Thompson parameterization currently in the CCPP after approval from all parties involved and significant testing.

This implementation is done in a way that will allow parallel testing of both TEMPO and the original Thompson microphysics.