### PR TITLE
HR4 and SFS baseline update: Improve convection/radiation interaction in the GFS physics suite

### DIFF
--- a/physics/CONV/SAMF/samfdeepcnv.f
+++ b/physics/CONV/SAMF/samfdeepcnv.f
@@ -215,7 +215,8 @@ cj
 !
 !  parameters for prognostic sigma closure                                                                                                                                                      
       real(kind=kind_phys) omega_u(im,km),zdqca(im,km),tmfq(im,km),
-     &     omegac(im),zeta(im,km),dbyo1(im,km),sigmab(im),qadv(im,km)
+     &     omegac(im),zeta(im,km),dbyo1(im,km),sigmab(im),qadv(im,km),
+     &     sigmaoutx(im)
       real(kind=kind_phys) gravinv,invdelt,sigmind,sigminm,sigmins
       parameter(sigmind=0.01,sigmins=0.03,sigminm=0.01)
       logical flag_shallow, flag_mid
@@ -3423,24 +3424,28 @@ c
         endif
       enddo
 c
-c  convective cloud water
+!
+      if(progsigma)then
+         do i = 1, im
+            sigmaoutx(i)=max(sigmaout(i,1),0.0)
+            sigmaoutx(i)=min(sigmaoutx(i),1.0)
+         enddo
+      endif
 c
 !> - Calculate convective cloud water.
       do k = 1, km
-        do i = 1, im
-          if (cnvflg(i) .and. rn(i) > 0.) then
-            if (k >= kbcon(i) .and. k < ktcon(i)) then
-               cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
-               if(progsigma)then
-                tem=max(sigmaout(i,k),0.)
-                tem1=min(tem,1.0)
-                cnvw(i,k)=cnvw(i,k)*tem1
-               else
-                cnvw(i,k)=cnvw(i,k)*sigmagfm(i)
+         do i = 1, im
+            if (cnvflg(i) .and. rn(i) > 0.) then
+               if (k >= kbcon(i) .and. k < ktcon(i)) then
+                  cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
+                  if(progsigma)then
+                     cnvw(i,k) = cnvw(i,k) * sigmaoutx(i)
+                  else
+                     cnvw(i,k) = cnvw(i,k) * sigmagfm(i)
+                  endif
                endif
             endif
-          endif
-        enddo
+         enddo
       enddo
 c
 c  convective cloud cover

--- a/physics/CONV/SAMF/samfdeepcnv.f
+++ b/physics/CONV/SAMF/samfdeepcnv.f
@@ -3431,9 +3431,13 @@ c
           if (cnvflg(i) .and. rn(i) > 0.) then
             if (k >= kbcon(i) .and. k < ktcon(i)) then
                cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
-               tem=max(sigmaout(i,k),0.)
-               tem1=min(tem,1.0)
-               cnvw(i,k)=cnvw(i,k)*tem1
+               if(progsigma)then
+                tem=max(sigmaout(i,k),0.)
+                tem1=min(tem,1.0)
+                cnvw(i,k)=cnvw(i,k)*tem1
+               else
+                cnvw(i,k)=cnvw(i,k)*sigmagfm(i)
+               endif
             endif
           endif
         enddo

--- a/physics/CONV/SAMF/samfdeepcnv.f
+++ b/physics/CONV/SAMF/samfdeepcnv.f
@@ -3430,7 +3430,10 @@ c
         do i = 1, im
           if (cnvflg(i) .and. rn(i) > 0.) then
             if (k >= kbcon(i) .and. k < ktcon(i)) then
-              cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
+               cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
+               tem=max(sigmaout(i,k),0.)
+               tem1=min(tem,1.0)
+               cnvw(i,k)=cnvw(i,k)*tem1
             endif
           endif
         enddo

--- a/physics/CONV/SAMF/samfshalcnv.f
+++ b/physics/CONV/SAMF/samfshalcnv.f
@@ -2405,7 +2405,10 @@ c
           if (cnvflg(i)) then
             if (k >= kbcon(i) .and. k < ktcon(i)) then
               cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
-            endif
+              tem=max(sigmaout(i,k),0.)
+              tem1=min(tem,1.0)
+              cnvw(i,k)=cnvw(i,k)*tem1
+           endif
           endif
         enddo
       enddo

--- a/physics/CONV/SAMF/samfshalcnv.f
+++ b/physics/CONV/SAMF/samfshalcnv.f
@@ -162,7 +162,7 @@ cc
 !  parameters for prognostic sigma closure
       real(kind=kind_phys) omega_u(im,km),zdqca(im,km),tmfq(im,km),
      &                     omegac(im),zeta(im,km),dbyo1(im,km),
-     &                     sigmab(im),qadv(im,km)
+     &                     sigmab(im),qadv(im,km),sigmaoutx(im)
       real(kind=kind_phys) gravinv,dxcrtas,invdelt,sigmind,sigmins,
      &                     sigminm
       logical flag_shallow,flag_mid
@@ -2397,27 +2397,29 @@ cj
         endif
       enddo
 c
-c  convective cloud water
-c
-!> - Calculate shallow convective cloud water.
+      if(progsigma)then
+         do i = 1, im
+            sigmaoutx(i)=max(sigmaout(i,1),0.0)
+            sigmaoutx(i)=min(sigmaoutx(i),1.0)
+         enddo
+      endif
+      
+c     convective cloud water
       do k = 1, km
-        do i = 1, im
-          if (cnvflg(i)) then
-            if (k >= kbcon(i) .and. k < ktcon(i)) then
-              cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
-              if(progsigma)then
-                tem=max(sigmaout(i,k),0.)
-                tem1=min(tem,1.0)
-		cnvw(i,k)=cnvw(i,k)*tem1
-              else
-                cnvw(i,k)=cnvw(i,k)*sigmagfm(i)
-             endif
-           endif
-          endif
-        enddo
+         do i = 1, im
+            if (cnvflg(i)) then
+               if (k >= kbcon(i) .and. k < ktcon(i)) then
+                  cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
+                  if (progsigma) then
+                     cnvw(i,k) = cnvw(i,k) * sigmaoutx(i)
+                  else
+                     cnvw(i,k) = cnvw(i,k) * sigmagfm(i)
+                  endif
+               endif
+            endif
+         enddo
       enddo
-
-c
+c     
 c  convective cloud cover
 c
 !> - Calculate convective cloud cover, which is used when pdf-based cloud fraction is used (i.e., pdfcld=.true.).

--- a/physics/CONV/SAMF/samfshalcnv.f
+++ b/physics/CONV/SAMF/samfshalcnv.f
@@ -2405,9 +2405,13 @@ c
           if (cnvflg(i)) then
             if (k >= kbcon(i) .and. k < ktcon(i)) then
               cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
-              tem=max(sigmaout(i,k),0.)
-              tem1=min(tem,1.0)
-              cnvw(i,k)=cnvw(i,k)*tem1
+              if(progsigma)then
+                tem=max(sigmaout(i,k),0.)
+                tem1=min(tem,1.0)
+		cnvw(i,k)=cnvw(i,k)*tem1
+              else
+                cnvw(i,k)=cnvw(i,k)*sigmagfm(i)
+             endif
            endif
           endif
         enddo

--- a/physics/PBL/SATMEDMF/satmedmfvdifq.F
+++ b/physics/PBL/SATMEDMF/satmedmfvdifq.F
@@ -275,7 +275,7 @@
       parameter(elmfac=1.0,elefac=1.0,cql=100.)
       parameter(dw2min=1.e-4,dkmax=1000.,xkgdx=1000.)
       parameter(qlcr=3.5e-5,zstblmax=2500.)
-      parameter(xkinv1=0.4,xkinv2=0.3)
+      parameter(xkinv1=0.15,xkinv2=0.3)
       parameter(h1=0.33333333,hcrinv=250.)
       parameter(vegflo=0.1,vegfup=1.0,z0lo=0.1,z0up=1.0)
       parameter(vc0=1.0,zc0=1.0)


### PR DESCRIPTION
Issue:
https://github.com/ufs-community/ufs-weather-model/issues/2339

This update is a collaboration between PSL, EMC, GSL, and DTC (@lisa-bengtsson, @JongilHan66 , @yangfanglin , @RuiyuSun , Weiwei Li and Shan Sun)

The GFS physics suite at 100km yields too large cloud cover and optical depth, causing too much cloud shielding and a drift in Sea Surface Temperatures, SST for seasonal prediction. This is an issue for the Seasonal Forecast System baseline. The issue was identified to be related to too much convective cloud condensate passed in from the cumulus convection scheme.

A scale adaptive solution is proposed and tested for SFS and GFS resolutions, outputting updraft values of in-cloud condensate. We propose to add this change to SFS baselines as well as the HR4 prototype of the GFS. In testing we also tune the minimum background diffusivity in the inversion layer near the PBL top (xkinv1) from xkinv1=0.4 to xkinv1=0.15 in order to not reduce convective clouds too much in marine stratocumulus. 

See presentation here: https://docs.google.com/presentation/d/11hP81jcBO2HZ1y4QOkBvwVOBqaPjw6cZUg-2JWF0FzI/edit#slide=id.g2e178e73b20_0_152
