### PR TITLE
[production/RRFS.v1] add a new parameter to control if G-F cold starts or not

### DIFF
--- a/physics/CONV/Grell_Freitas/cu_gf_driver.F90
+++ b/physics/CONV/Grell_Freitas/cu_gf_driver.F90
@@ -56,7 +56,7 @@ contains
 !! \htmlinclude cu_gf_driver_run.html
 !!
 !>\section gen_gf_driver Grell-Freitas Cumulus Scheme Driver General Algorithm
-      subroutine cu_gf_driver_run(ntracer,garea,im,km,dt,flag_init,flag_restart,&
+      subroutine cu_gf_driver_run(ntracer,garea,im,km,dt,flag_init,flag_restart, gf_coldstart, &
                cactiv,cactiv_m,g,cp,xlv,r_v,forcet,forceqv_spechum,phil,raincv, &
                qv_spechum,t,cld1d,us,vs,t2di,w,qv2di_spechum,p2di,psuri,        &
                hbot,htop,kcnv,xland,hfx2,qfx2,aod_gf,cliw,clcw,                 &
@@ -97,7 +97,7 @@ contains
    integer      :: its,ite, jts,jte, kts,kte
    integer, intent(in   ) :: im,km,ntracer,nchem,kdt
    integer, intent(in   ) :: ichoice_in,ichoicem_in,ichoice_s_in
-   logical, intent(in   ) :: flag_init, flag_restart, do_mynnedmf
+   logical, intent(in   ) :: flag_init, flag_restart, do_mynnedmf, gf_coldstart
    logical, intent(in   ) :: flag_for_scnv_generic_tend,flag_for_dcnv_generic_tend
    real (kind=kind_phys), intent(in) :: g,cp,xlv,r_v
    logical, intent(in   ) :: ldiag3d
@@ -427,7 +427,7 @@ contains
       ccn_m(i) = 0.
 
       ! set aod and ccn
-      if (flag_init .and. .not.flag_restart) then
+      if ((flag_init .and. .not.flag_restart) .or. gf_coldstart) then
         aod_gf(i)=aodc0
       else
         if((cactiv(i).eq.0) .and. (cactiv_m(i).eq.0))then

--- a/physics/CONV/Grell_Freitas/cu_gf_driver.meta
+++ b/physics/CONV/Grell_Freitas/cu_gf_driver.meta
@@ -577,6 +577,13 @@
   dimensions = ()
   type = logical
   intent = in
+[gf_coldstart]
+  standard_name = flag_for_cold_start_gf
+  long_name = flag to cold start G-F 
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [ichoice_in]
   standard_name = identifier_for_c3_or_gf_deep_convection_closure
   long_name = flag for C3 or GF deep convection closure

--- a/physics/CONV/Grell_Freitas/cu_gf_driver_pre.F90
+++ b/physics/CONV/Grell_Freitas/cu_gf_driver_pre.F90
@@ -15,7 +15,7 @@ module cu_gf_driver_pre
 !> \section arg_table_cu_gf_driver_pre_run Argument Table
 !! \htmlinclude cu_gf_driver_pre_run.html
 !!
-   subroutine cu_gf_driver_pre_run (flag_init, flag_restart, kdt, fhour, dtp, t, q, prevst, prevsq, &
+   subroutine cu_gf_driver_pre_run (flag_init, flag_restart, gf_coldstart, kdt, fhour, dtp, t, q, prevst, prevsq, &
                                     forcet, forceq, cactiv, cactiv_m, conv_act, conv_act_m,         &
                                     rrfs_sd, ntsmoke, ntdust, ntcoarsepm, chem3d, gq0,              &
                                     errmsg, errflg)
@@ -26,6 +26,7 @@ module cu_gf_driver_pre
 
       logical,          intent(in)  :: flag_init
       logical,          intent(in)  :: flag_restart
+      logical,          intent(in)  :: gf_coldstart 
       logical,          intent(in)  :: rrfs_sd
       integer,          intent(in)  :: kdt
       real(kind_phys),  intent(in)  :: fhour
@@ -58,7 +59,7 @@ module cu_gf_driver_pre
       ! For restart runs, can assume that prevst and prevsq
       ! are read from the restart files beforehand, same
       ! for conv_act.
-      if(flag_init .and. .not.flag_restart) then
+      if((flag_init .and. .not.flag_restart) .or. gf_coldstart) then
 !$acc kernels
         forcet(:,:)=0.0
         forceq(:,:)=0.0

--- a/physics/CONV/Grell_Freitas/cu_gf_driver_pre.meta
+++ b/physics/CONV/Grell_Freitas/cu_gf_driver_pre.meta
@@ -122,6 +122,13 @@
   type = real
   kind = kind_phys
   intent = in
+[gf_coldstart]
+  standard_name = flag_for_cold_start_gf
+  long_name = flag to cold start G-F 
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [rrfs_sd]
   standard_name = do_smoke_coupling
   long_name = flag controlling rrfs_sd collection


### PR DESCRIPTION
After RRFS cycled DA switched to using saSAS, REFS members using G-F convection failed due to missing restarting variables. This PR will add a new parameter to control whether G-F will be cold started or not. The parameter will be set to false by default and won't affect any existing code logic/structure. 