### PR TITLE
[production/RRFS.v1]saSAS sigmab initialization modification during the first timestep

### DIFF
--- a/physics/CONV/SAMF/samfdeepcnv.f
+++ b/physics/CONV/SAMF/samfdeepcnv.f
@@ -12,10 +12,11 @@
       contains
 
       subroutine samfdeepcnv_init(imfdeepcnv,imfdeepcnv_samf,            &
-     &                            errmsg, errflg)
+     &                            sigmab_coldstart,errmsg, errflg)
 
       integer,                   intent(in) :: imfdeepcnv
       integer,                   intent(in) :: imfdeepcnv_samf
+      logical,                   intent(in) :: sigmab_coldstart
       character(len=*),          intent(out) :: errmsg
       integer,                   intent(out) :: errflg
 
@@ -84,7 +85,7 @@
      &    clam,c0s,c1,betal,betas,evef,pgcon,asolfac,                   &
      &    do_ca, ca_closure, ca_entr, ca_trigger, nthresh,ca_deep,      &
      &    rainevap,sigmain,sigmaout,betadcu,betamcu,betascu,            &
-     &    maxMF, do_mynnedmf,errmsg,errflg)
+     &    maxMF, do_mynnedmf,sigmab_coldstart,errmsg,errflg)
 !
       use machine , only : kind_phys
       use funcphys , only : fpvs
@@ -100,7 +101,7 @@
      &   prslp(:,:),  garea(:), hpbl(:), dot(:,:), phil(:,:)
       real(kind=kind_phys), dimension(:), intent(in) :: fscav
       logical, intent(in)  :: first_time_step,restart,hwrf_samfdeep,    &
-     &     progsigma,do_mynnedmf
+     &     progsigma,do_mynnedmf,sigmab_coldstart
       real(kind=kind_phys), intent(in) :: nthresh,betadcu,betamcu,      &
      &                                    betascu
       real(kind=kind_phys), intent(in) :: ca_deep(:)
@@ -2915,7 +2916,7 @@ c
       if(progsigma)then
 
 !Initial computations, dynamic q-tendency                                                                                                                                               
-         if(first_time_step .and. .not.restart)then
+         if(first_time_step .and. (.not.restart .or. sigmab_coldstart))then
             do k = 1,km
                do i = 1,im
                   qadv(i,k)=0.

--- a/physics/CONV/SAMF/samfdeepcnv.f
+++ b/physics/CONV/SAMF/samfdeepcnv.f
@@ -12,11 +12,10 @@
       contains
 
       subroutine samfdeepcnv_init(imfdeepcnv,imfdeepcnv_samf,            &
-     &                            sigmab_coldstart,errmsg, errflg)
+     &                            errmsg, errflg)
 
       integer,                   intent(in) :: imfdeepcnv
       integer,                   intent(in) :: imfdeepcnv_samf
-      logical,                   intent(in) :: sigmab_coldstart
       character(len=*),          intent(out) :: errmsg
       integer,                   intent(out) :: errflg
 
@@ -2916,7 +2915,8 @@ c
       if(progsigma)then
 
 !Initial computations, dynamic q-tendency                                                                                                                                               
-         if(first_time_step .and. (.not.restart .or. sigmab_coldstart))then
+         if(first_time_step .and. (.not.restart 
+     &           .or. sigmab_coldstart))then
             do k = 1,km
                do i = 1,im
                   qadv(i,k)=0.

--- a/physics/CONV/SAMF/samfdeepcnv.meta
+++ b/physics/CONV/SAMF/samfdeepcnv.meta
@@ -488,6 +488,13 @@
   dimensions = ()
   type = logical
   intent = in
+[sigmab_coldstart]
+  standard_name = flag_to_cold_start_for_sigmab_init
+  long_name = flag to cold start for sigmab initialization
+  units = flag
+  dimensions = ()
+  type = logical 
+  intent = in
 [qlcn]
   standard_name = mass_fraction_of_convective_cloud_liquid_water
   long_name = mass fraction of convective cloud liquid water

--- a/physics/CONV/progsigma_calc.f90
+++ b/physics/CONV/progsigma_calc.f90
@@ -174,13 +174,6 @@
       enddo
 
       !sigmab
-!      if(flag_init .and. .not. flag_restart)then
-!         do i = 1,im
-!            if(cnvflg(i))then
-!               sigmab(i)=0.03
-!            endif
-!         enddo
-!      else
          do i = 1,im
             if(cnvflg(i))then
                DEN=MIN(termC(i)+termB(i),1.E8)

--- a/physics/CONV/progsigma_calc.f90
+++ b/physics/CONV/progsigma_calc.f90
@@ -54,7 +54,7 @@
 
       real(kind=kind_phys) :: gcvalmx,epsilon,ZZ,cvg,mcon,buy2,   &
                           fdqb,dtdyn,dxlim,rmulacvg,tem,     &
-                          DEN,dp1,invdelt
+                          DEN,dp1,invdelt,sigmind_new
 
      !Parameters
       gcvalmx = 0.1
@@ -62,6 +62,12 @@
       epsilon=1.E-11
       km1=km-1
       invdelt = 1./delt
+
+      if (flag_init) then
+           sigmind_new=0.0
+      else
+           sigmind_new=sigmind
+      end if
 
      !Initialization 2D
       do k = 1,km
@@ -168,13 +174,13 @@
       enddo
 
       !sigmab
-      if(flag_init .and. .not. flag_restart)then
-         do i = 1,im
-            if(cnvflg(i))then
-               sigmab(i)=0.03
-            endif
-         enddo
-      else
+!      if(flag_init .and. .not. flag_restart)then
+!         do i = 1,im
+!            if(cnvflg(i))then
+!               sigmab(i)=0.03
+!            endif
+!         enddo
+!      else
          do i = 1,im
             if(cnvflg(i))then
                DEN=MIN(termC(i)+termB(i),1.E8)
@@ -186,11 +192,11 @@
                sigmab(i)=(ZZ*(termA(i)+cvg))/(DEN+(1.0-ZZ))
                if(sigmab(i)>0.)then
                   sigmab(i)=MIN(sigmab(i),0.95)  
-                  sigmab(i)=MAX(sigmab(i),0.01)
+                  sigmab(i)=MAX(sigmab(i),sigmind_new)
                endif
             endif!cnvflg
          enddo
-      endif
+!      endif
 
       do k=1,km
          do i=1,im
@@ -219,7 +225,7 @@
          do i= 1, im
             if(cnvflg(i)) then
                sigmab(i)=sigmab(i)/betadcu
-               sigmab(i)=MAX(sigmind,sigmab(i))
+               sigmab(i)=MAX(sigmind_new,sigmab(i))
             endif
          enddo
       endif

--- a/physics/CONV/progsigma_calc.f90
+++ b/physics/CONV/progsigma_calc.f90
@@ -189,7 +189,6 @@
                endif
             endif!cnvflg
          enddo
-!      endif
 
       do k=1,km
          do i=1,im


### PR DESCRIPTION
This PR follows Jongil's suggestion and aims to reduce the large convective reflectivity caused by saSAS adjustment in the first timestep during a warm start. The issue is likely related to the inconsistency when DA updates the moisture at t but not the moisture from the previous timestep (t-36s). The moisture from the previous timestep is needed for initializing sigmab (updraft area fraction) when calculating qadv (q advection or tendency term).

The PR forces qadv to zero in the first timestep when a namelist parameter sigmab_coldstart is set to .true. It also reduces the lower limit of sigmab from 0.01 to 0.0 in the first timestep.

[sigmab_modification.pptx](https://github.com/user-attachments/files/16999088/sigmab_modification.pptx)
    