### PR TITLE
Fifth reconciliation PR from production/RRFS.v1

### DIFF
--- a/physics/MP/Thompson/module_mp_thompson.F90
+++ b/physics/MP/Thompson/module_mp_thompson.F90
@@ -3615,7 +3615,7 @@ module module_mp_thompson
 
    !+---+-----------------------------------------------------------------+ !  EVAPORATION
                elseif (clap .lt. -eps .AND. ssatw(k).lt.-1.E-6 .AND.     &
-                        (is_aerosol_aware .or. merra2_aerosol_aware)) then  
+                        is_aerosol_aware) then  
                   tempc = temp(k) - 273.15
                   otemp = 1./temp(k)
                   rvs = rho(k)*qvs(k)

--- a/physics/smoke_dust/module_add_emiss_burn.F90
+++ b/physics/smoke_dust/module_add_emiss_burn.F90
@@ -76,15 +76,6 @@ CONTAINS
 !                   the eastern US,   max_ti= 20.041288* 3600.
 !                   else   max_ti= 18.041288* 3600.
 !                   endif
-! RAR: for option #1 ebb and frp are ingested for 24 hours. No modification is
-! applied! 
-    if (ebb_dcycle==1) then
-      do k=kts,kte
-        do i=its,ite
-         ebu(i,k,1)=ebu_in(i,1)   ! RAR:          
-        enddo
-      enddo
-     endif
 
     if (ebb_dcycle==2) then
 

--- a/physics/smoke_dust/module_add_emiss_burn.F90
+++ b/physics/smoke_dust/module_add_emiss_burn.F90
@@ -66,23 +66,6 @@ CONTAINS
     timeq= mod(timeq,timeq_max)
     coef_con=1._kind_phys/((2._kind_phys*pi)**0.5)
 
-
-! RAR: Grasslands (29% of ther western HRRR CONUS domain) probably also need to
-! be added below, check this later
-! RAR: In the HRRR CONUS domain (western part) crop 11%, 2% cropland/natural
-! vegetation and 0.4% urban of pixels
-!.OR. lu_index(i,j)==14)  then ! Croplands(12), Urban and Built-Up(13),
-!cropland/natural vegetation (14) mosaic in MODI-RUC vegetation classes
-! Peak hours for the fire activity depending on the latitude
-!                   if (xlong(i,j)<-130.) then  max_ti= 24.041288* 3600.    !
-!                   peak at 24 UTC, fires in  Alaska
-!                   elseif (xlong(i,j)<-100.) then   max_ti= 22.041288* 3600.
-!                   ! peak at 22 UTC, fires in the western US
-!                   elseif (xlong(i,j)<-70.) then   ! peak at 20 UTC, fires in
-!                   the eastern US,   max_ti= 20.041288* 3600.
-!                   else   max_ti= 18.041288* 3600.
-!                   endif
-
     if (ebb_dcycle==2) then
     
      do j=jts,jte


### PR DESCRIPTION
This is identical to https://github.com/ufs-community/ccpp-physics/pull/191, but targeted at ufs/dev.

For ebb_dcycle==1 (retrospective fire emissions), the 3-d emissions were incorrectly assgined assigned at all levels using the surface data.

This address Issue https://github.com/ufs-community/ccpp-physics/issues/188