### PR TITLE
Sixth reconciliation PR from production/RRFS.v1

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_debug.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_debug.F90
@@ -694,6 +694,7 @@
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%dlwsfci     ',    Diag%dlwsfci)
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%ulwsfci     ',    Diag%ulwsfci)
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%dswsfci     ',    Diag%dswsfci)
+                     call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%dswsfcci    ',    Diag%dswsfcci)
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%nswsfci     ',    Diag%nswsfci)
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%uswsfci     ',    Diag%uswsfci)
                      call print_var(mpirank, omprank, blkno, Grid%xlat_d, Grid%xlon_d, 'Diag%dusfci      ',    Diag%dusfci)

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.F90
@@ -24,7 +24,7 @@ contains
                                  flag_cice, cplflx, cplice, cplwav2atm, lsm, lsm_ruc,                                     &
                                  landfrac, lakefrac, lakedepth, oceanfrac, frland,                                        &
                                  dry, icy, lake, use_lake_model, wet, hice, cice, zorlo, zorll, zorli,                    &
-                                 snowd,            snowd_lnd, snowd_ice, tprcp, tprcp_wat,                                &
+                                 snowd,            snowd_lnd, snowd_ice, tprcp, tprcp_wat, tgrs1,                         &
                                  tprcp_lnd, tprcp_ice, uustar, uustar_wat, uustar_lnd, uustar_ice,                        &
                                  weasd,            weasd_lnd, weasd_ice, ep1d_ice, tsfc, tsfco, tsfcl, tsfc_wat,          &
                                            tisfc, tsurf_wat, tsurf_lnd, tsurf_ice,                                        &
@@ -45,6 +45,7 @@ contains
       real(kind=kind_phys), dimension(:), intent(in   )  :: snowd, tprcp, uustar, weasd, qss, tisfc
 
       real(kind=kind_phys), dimension(:), intent(inout)  :: tsfc, tsfco, tsfcl
+      real(kind=kind_phys), dimension(:), intent(inout)  :: tgrs1
       real(kind=kind_phys), dimension(:), intent(inout)  :: snowd_lnd, snowd_ice, tprcp_wat,            &
                     tprcp_lnd, tprcp_ice, tsfc_wat, tsurf_wat,tsurf_lnd, tsurf_ice,                     &
                     uustar_wat, uustar_lnd, uustar_ice, weasd_lnd, weasd_ice,                           &
@@ -179,6 +180,13 @@ contains
                 else
                   if (icy(i)) tsfco(i) = max(tisfc(i), tgice)
                 endif
+              else
+                wet(i) = .false. ! no open ocean
+              endif
+              if(wet(i) .and. tsfco(i) < 0) then
+                1013 format('using tgrs1 instead of bad tsfco(i=',I0,')=',E20.12,' slmsk(i)=',E12.7,' cice(i)=',E12.7,' islmsk(i)=',I0,' islmsk_cice(i)=',I0,' oceanfrac(i)=',E12.7,' cplice=',L1,' icy(i)=',L1,' cplflx=',L1)
+                write(0,1013) i,tsfco(i),slmsk(i),cice(i),islmsk(i),islmsk_cice(i),oceanfrac(i),cplice,icy(i),cplflx
+                tsfco(i) = tgrs1(i)
               endif
             else ! Not ocean and not land
               is_clm = lkm>0 .and. iopt_lake==iopt_lake_clm .and. use_lake_model(i)>0

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.meta
@@ -223,6 +223,14 @@
   type = real
   kind = kind_phys
   intent = inout
+[tgrs1]
+  standard_name = air_temperature_at_surface_adjacent_layer
+  long_name = mean temperature at lowest model layer
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
 [tprcp]
   standard_name = nonnegative_lwe_thickness_of_precipitation_amount_on_dynamics_timestep
   long_name = total precipitation amount in each time step

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.f
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.f
@@ -36,7 +36,7 @@
 !          ( solhr,slag,sdec,cdec,sinlat,coslat,                        !
 !            xlon,coszen,tsfc_lnd,tsfc_ice,tsfc_wat,                    !
 !            tf,tsflw,sfcemis_lnd,sfcemis_ice,sfcemis_wat,              !
-!            sfcdsw,sfcnsw,sfcdlw,sfculw,swh,swhc,hlw,hlwc,             !
+!            sfcdsw,sfcdswc,sfcnsw,sfcdlw,sfculw,swh,swhc,hlw,hlwc,     !
 !            sfcnirbmu,sfcnirdfu,sfcvisbmu,sfcvisdfu,                   !
 !            sfcnirbmd,sfcnirdfd,sfcvisbmd,sfcvisdfd,                   !
 !            im, levs, deltim, fhswr,                                   !
@@ -68,6 +68,7 @@
 !     sfcemis_wat(im) - real, surface emissivity (fraction) o. ocean (k)!
 !     tsflw  (im)  - real, sfc air (layer 1) temp in k saved in lw call !
 !     sfcdsw (im)  - real, total sky sfc downward sw flux ( w/m**2 )    !
+!     sfcdswc (im) - real, clear sky sfc downward sw flux ( w/m**2 )    !
 !     sfcnsw (im)  - real, total sky sfc net sw into ground (w/m**2)    !
 !     sfcdlw (im)  - real, total sky sfc downward lw flux ( w/m**2 )    !
 !     sfculw (im)  - real, total sky sfc upward lw flux ( w/m**2 )    !
@@ -98,6 +99,7 @@
 !                                                                       !
 !  outputs:                                                             !
 !     adjsfcdsw(im)- real, time step adjusted sfc dn sw flux (w/m**2)   !
+!     adjsfcdswc(im)- real, time step adjusted sfc dn sw flux (w/m**2)  !
 !     adjsfcnsw(im)- real, time step adj sfc net sw into ground (w/m**2)!
 !     adjsfcdlw(im)- real, time step adjusted sfc dn lw flux (w/m**2)   !
 !     adjsfculw_lnd(im)- real, sfc upw. lw flux at current time (w/m**2)!
@@ -169,7 +171,7 @@
      &       con_g, con_cp, con_pi, con_sbc,                            &
      &       xlon,coszen,tsfc_lnd,tsfc_ice,tsfc_wat,tf,tsflw,tsfc,      &
      &       sfcemis_lnd, sfcemis_ice, sfcemis_wat,                     &
-     &       sfcdsw,sfcnsw,sfcdlw,swh,swhc,hlw,hlwc,                    &
+     &       sfcdsw,sfcdswc,sfcnsw,sfcdlw,swh,swhc,hlw,hlwc,            &
      &       sfcnirbmu,sfcnirdfu,sfcvisbmu,sfcvisdfu,                   &
      &       sfcnirbmd,sfcnirdfd,sfcvisbmd,sfcvisdfd,                   &
      &       im, levs, deltim, fhswr,                                   &
@@ -181,7 +183,7 @@
 !  ---  input/output:
      &       dtdt,dtdtnp,htrlw,                                         &
 !  ---  outputs:
-     &       adjsfcdsw,adjsfcnsw,adjsfcdlw,                             &
+     &       adjsfcdsw,adjsfcdswc,adjsfcnsw,adjsfcdlw,                  &
      &       adjsfculw_lnd,adjsfculw_ice,adjsfculw_wat,xmu,xcosz,       &
      &       adjnirbmu,adjnirdfu,adjvisbmu,adjvisdfu,                   &
      &       adjnirbmd,adjnirdfd,adjvisbmd,adjvisdfd,                   &
@@ -214,7 +216,7 @@
 
       real(kind=kind_phys), dimension(:), intent(in) ::                 &
      &      sinlat, coslat, xlon, coszen, tf, tsflw, sfcdlw,            &
-     &      sfcdsw, sfcnsw, sfculw, tsfc
+     &      sfcdsw, sfcdswc, sfcnsw, sfculw, tsfc
       real(kind=kind_phys), dimension(:), intent(in), optional ::       &
      &      sfculw_med, tsfc_radtime
       real(kind=kind_phys), dimension(:), intent(in) ::                 &
@@ -247,7 +249,7 @@
       real(kind=kind_phys), dimension(:), intent(out) ::                &
      &      adjsfcdsw, adjsfcnsw, adjsfcdlw, xmu, xcosz,                &
      &      adjnirbmu, adjnirdfu, adjvisbmu, adjvisdfu,                 &
-     &      adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd
+     &      adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfcdswc
 
       real(kind=kind_phys), dimension(:), intent(out) ::                &
      &      adjsfculw_lnd, adjsfculw_ice, adjsfculw_wat
@@ -370,6 +372,7 @@
 
         adjsfcnsw(i) = sfcnsw(i)    * xmu(i)
         adjsfcdsw(i) = sfcdsw(i)    * xmu(i)
+        adjsfcdswc(i)= sfcdswc(i)   * xmu(i)
 
         adjnirbmu(i) = sfcnirbmu(i) * xmu(i)
         adjnirdfu(i) = sfcnirdfu(i) * xmu(i)

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.f
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.f
@@ -44,7 +44,7 @@
 !      input/output:                                                    !
 !            dtdt,dtdtnp,                                               !
 !      outputs:                                                         !
-!            adjsfcdsw,adjsfcnsw,adjsfcdlw,                             !
+!            adjsfcdsw,adjsfcdswc,adjsfcnsw,adjsfcdlw,                  !
 !            adjsfculw_lnd,adjsfculw_ice,adjsfculw_wat,xmu,xcosz,       !
 !            adjnirbmu,adjnirdfu,adjvisbmu,adjvisdfu,                   !
 !            adjdnnbmd,adjdnndfd,adjdnvbmd,adjdnvdfd)                   !

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/dcyc2t3.meta
@@ -191,6 +191,14 @@
   type = real
   kind = kind_phys
   intent = in
+[sfcdswc]
+  standard_name = surface_downwelling_shortwave_flux_on_radiation_timestep_assuming_clear_sky
+  long_name = clear sky surface downwelling shortwave flux on radiation time step
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
 [sfcdlw]
   standard_name = surface_downwelling_longwave_flux_on_radiation_timestep
   long_name = total sky surface downwelling longwave flux on radiation time step
@@ -510,6 +518,14 @@
 [adjsfcdsw]
   standard_name = surface_downwelling_shortwave_flux
   long_name = surface downwelling shortwave flux at current time
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = out
+[adjsfcdswc]
+  standard_name = surface_downwelling_shortwave_flux_assuming_clear_sky
+  long_name = surface downwelling shortwave flux at current time assuming clear sky
   units = W m-2
   dimensions = (horizontal_loop_extent)
   type = real

--- a/physics/Radiation/RRTMG/rrtmg_sw_post.F90
+++ b/physics/Radiation/RRTMG/rrtmg_sw_post.F90
@@ -14,7 +14,7 @@
                  swhtr, sfcalb1, sfcalb2, sfcalb3, sfcalb4, htswc, htsw0,      &
                  nirbmdi, nirdfdi, visbmdi, visdfdi, nirbmui, nirdfui, visbmui,&
                  visdfui, sfcdsw, sfcnsw, htrsw, swhc, scmpsw, sfcfsw, topfsw, &
-                 errmsg, errflg)
+                 sfcdswc, errmsg, errflg)
 
       use machine,                   only: kind_phys
       use module_radsw_parameters,   only: topfsw_type, sfcfsw_type,   &
@@ -33,7 +33,8 @@
                                                              visbmdi, visdfdi, &
                                                              nirbmui, nirdfui, &
                                                              visbmui, visdfui, &
-                                                             sfcdsw,  sfcnsw
+                                                             sfcdsw,  sfcnsw,  &
+                                                             sfcdswc
       real(kind=kind_phys), dimension(:,:), intent(inout) :: htrsw, swhc
 
       type(cmpfsw_type), dimension(:),     intent(inout) :: scmpsw
@@ -122,6 +123,7 @@
         do i=1,im
           sfcnsw(i) = sfcfsw(i)%dnfxc - sfcfsw(i)%upfxc
           sfcdsw(i) = sfcfsw(i)%dnfxc
+          sfcdswc(i)= sfcfsw(i)%dnfx0
         enddo
 
       endif                                ! end_if_lsswr

--- a/physics/Radiation/RRTMG/rrtmg_sw_post.meta
+++ b/physics/Radiation/RRTMG/rrtmg_sw_post.meta
@@ -198,6 +198,14 @@
   type = real
   kind = kind_phys
   intent = inout
+[sfcdswc]
+  standard_name = surface_downwelling_shortwave_flux_on_radiation_timestep_assuming_clear_sky
+  long_name = clear sky sfc downward sw flux
+  units = W m-2
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
 [htrsw]
   standard_name = tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep
   long_name = total sky sw heating rate


### PR DESCRIPTION
Identical to https://github.com/ufs-community/ccpp-physics/pull/198

This is @dustinswales work.

This PR adds a new diagnostic, instantaneous downward shortwave flux at the surface assuming clear-sky conditions.

#247 is combined into this PR:

Fixes this problem:

- https://github.com/ufs-community/ufs-weather-model/issues/2547

It was caused by missing values (-1e+20) for sea surface temperature on `wet` points in input data. (`Wet` points are points where the CCPP `wet` array is true, thus indicating the surface is at least partly water.) There's a bug fix and a workaround:

1. Bug fix: In certain situations, the `wet` array can be mistakenly true when it should be false due to the location being 100% ice. An "else" statement corrects this.
2. Workaround: If the input sea surface temperatures (tsfco) are invalid on a `wet` point, the lowest model level temperature is used instead.

There is no other temperature available on those points that can reasonably be used as a sea surface temperature. The lowest model level temperature may not be a perfect analogue for the sea surface temperature, but it'll be more realistic than -1E+20 K.