### PR TITLE
Updates to radiation, cloud, and land processes for improved surface temperature and radiative flux biases

### DIFF
--- a/physics/MP/Thompson/module_mp_thompson.F90
+++ b/physics/MP/Thompson/module_mp_thompson.F90
@@ -93,7 +93,7 @@ module module_mp_thompson
 !.. droplet number concentration.
    !real(wp), parameter :: Nt_c = 100.e6
    real(wp), parameter :: Nt_c_o = 50.e6
-   real(wp), parameter :: Nt_c_l = 100.e6
+   real(wp), parameter :: Nt_c_l = 150.e6
    real(wp), parameter, private :: Nt_c_max = 1999.e6
 
 !..Declaration of constants for assumed CCN/IN aerosols when none in

--- a/physics/Radiation/radiation_clouds.f
+++ b/physics/Radiation/radiation_clouds.f
@@ -197,9 +197,10 @@
       real (kind=kind_phys), parameter :: ovcst  = 1.0 - 1.0e-8
 
       real (kind=kind_phys), parameter :: reliq_def = 10.0        !< default liq radius to 10 micron
-      real (kind=kind_phys), parameter :: reice_def = 25.0        !< default ice radius to 50 micron
+      real (kind=kind_phys), parameter :: reice_def = 50.0        !< default ice radius to 50 micron
       real (kind=kind_phys), parameter :: rrain_def = 1000.0      !< default rain radius to 1000 micron
       real (kind=kind_phys), parameter :: rsnow_def = 250.0       !< default snow radius to 250 micron
+      real (kind=kind_phys), parameter :: creice_def = 25.0       !< default convective ice radius to 25 micron overland
 
       real (kind=kind_phys), parameter :: cldssa_def = 0.99       !< default cld single scat albedo
       real (kind=kind_phys), parameter :: cldasy_def = 0.84       !< default cld asymmetry factor
@@ -2164,8 +2165,13 @@
             cip(i,k) = max(0.0, (clw(i,k,ntiw) +
      &             snow2ice*clw(i,k,ntsw) + tem2) *
      &             gfac * delp(i,k))
-            if(tem2 > 1.e-12 .and.  clw(i,k,ntiw) < 1.e-12)
-     &             rei(i,k)=reice_def
+            if(tem2 > 1.e-12 .and.  clw(i,k,ntiw) < 1.e-12) then
+                 if(nint(slmsk(i))==1) then
+                   rei(i,k)=creice_def
+                 else
+                   rei(i,k)=reice_def
+                 endif
+            endif       
             crp(i,k) = max(0.0, clw(i,k,ntrw) * gfac * delp(i,k))
             csp(i,k) = max(0.0, (1.-snow2ice)*clw(i,k,ntsw) *
      &             gfac * delp(i,k))

--- a/physics/Radiation/radiation_clouds.f
+++ b/physics/Radiation/radiation_clouds.f
@@ -197,7 +197,7 @@
       real (kind=kind_phys), parameter :: ovcst  = 1.0 - 1.0e-8
 
       real (kind=kind_phys), parameter :: reliq_def = 10.0        !< default liq radius to 10 micron
-      real (kind=kind_phys), parameter :: reice_def = 50.0        !< default ice radius to 50 micron
+      real (kind=kind_phys), parameter :: reice_def = 25.0        !< default ice radius to 50 micron
       real (kind=kind_phys), parameter :: rrain_def = 1000.0      !< default rain radius to 1000 micron
       real (kind=kind_phys), parameter :: rsnow_def = 250.0       !< default snow radius to 250 micron
 

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
@@ -842,12 +842,14 @@ contains
 
 ! snow albedos: age even when sun is not present
 
+  if(cosz > 0) then
   if(opt_alb == 1) &
      call snowalb_bats_glacier (nband,cosz,fage,albsnd,albsni)
   if(opt_alb == 2) then
      call snowalb_class_glacier(nband,qsnow,dt,alb,albold,albsnd,albsni)
      albold = alb
   end if
+  end if 
 
 ! zero summed solar fluxes
 

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90
@@ -3024,7 +3024,7 @@ endif   ! croptype == 0
   
   call snow_age (parameters,dt,tg,sneqvo,sneqv,tauss,fage) 
   
-  if(cosz > 0) 
+  if(cosz > 0) then 
 
 ! weight reflectance/transmittance by lai and sai
 
@@ -3043,7 +3043,6 @@ endif   ! croptype == 0
   if(opt_alb == 2) then
      call snowalb_class (parameters,nband,qsnow,dt,alb,albold,albsnd,albsni,iloc,jloc)
      albold = alb
-  end if
   end if
 
 ! ground surface albedo
@@ -3085,8 +3084,7 @@ endif   ! croptype == 0
      wl = ext 
   end if
   fsun = wl
-
-100 continue
+  end if
 
   end subroutine albedo
 

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90
@@ -2511,7 +2511,19 @@ endif   ! croptype == 0
   real (kind=kind_phys), dimension(-nsnow+1:    0)              :: tksno   !snow thermal conductivity (j/m3/k)
   real (kind=kind_phys), dimension(       1:nsoil)              :: sice    !soil ice content
   real (kind=kind_phys), parameter :: sbeta = -2.0
+  real (kind=kind_phys), dimension(4,20)   :: soil_carbon                  ! soil carbon content [kg/m3]
+  real (kind=kind_phys), parameter         :: soil_carbon_df = 0.25        ! soil carbon therm cond (Lawrence and Slater)
+  real (kind=kind_phys), parameter         :: soil_carbon_hcpct = 2.5e6    ! soil carbon heat capacity (Lawrence and Slater)
 ! --------------------------------------------------------------------------------------------------
+! soil carbon [kg/m3] by vegetation type estimated from global PNNL soil carbon dataset
+!   and VIIRS surface type
+
+  soil_carbon(1,:) = (/90,65,90,65,90,40,50,50,40,50,90,60,60,60,0,20,0,90,90,60/)
+  soil_carbon(2,:) = (/40,30,40,30,40,25,30,30,25,30,40,30,30,30,0,15,0,60,60,40/)
+  soil_carbon(3,:) = (/20,15,20,15,20,15,20,15,15,15,25,20,20,20,0,10,0,40,40,30/)
+  soil_carbon(4,:) = (/15,10,15,10,15,10,15,10,10,10,20,10,10,10,0,10,0,40,30,20/)
+
+  soil_carbon = soil_carbon / 130.0   ! convert to soil carbon relative to peat
 
 ! compute snow thermal conductivity and heat capacity
 
@@ -2530,6 +2542,11 @@ endif   ! croptype == 0
        hcpct(iz) = sh2o(iz)*cwat + (1.0-parameters%smcmax(iz))*parameters%csoil &
                 + (parameters%smcmax(iz)-smc(iz))*cpair + sice(iz)*cice
        call tdfcnd (parameters,iz,df(iz), smc(iz), sh2o(iz))
+
+! adjust for soil carbon organic content
+
+!      hcpct(iz) = (1.0 - soil_carbon(iz,vegtyp)) * hcpct(iz) + soil_carbon(iz,vegtyp) * soil_carbon_hcpct
+       df(iz)    = (1.0 - soil_carbon(iz,vegtyp)) * df(iz)    + soil_carbon(iz,vegtyp) * soil_carbon_df
     end do
        
     if ( parameters%urban_flag ) then
@@ -3003,6 +3020,10 @@ endif   ! croptype == 0
     if (ib.eq.1) fsun = 0.
   end do
 
+! snow age
+  
+  call snow_age (parameters,dt,tg,sneqvo,sneqv,tauss,fage) 
+  
   if(cosz <= 0) goto 100
 
 ! weight reflectance/transmittance by lai and sai
@@ -3014,10 +3035,6 @@ endif   ! croptype == 0
     rho(ib) = max(parameters%rhol(ib)*wl+parameters%rhos(ib)*ws, mpe)
     tau(ib) = max(parameters%taul(ib)*wl+parameters%taus(ib)*ws, mpe)
   end do
-
-! snow age
-
-   call snow_age (parameters,dt,tg,sneqvo,sneqv,tauss,fage)
 
 ! snow albedos: only if cosz > 0 and fsno > 0
 
@@ -9128,7 +9145,9 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
 
 !      ka  = hk(iwt)
 ! harmonic average, c.he changed based on gy niu's update
-      ka  = 2.0*(hk(iwt)*parameters%dksat(iwt)*1.0e3) / (hk(iwt)+parameters%dksat(iwt)*1.0e3)
+!      ka  = 2.0*(hk(iwt)*parameters%dksat(iwt)*1.0e3) / (hk(iwt)+parameters%dksat(iwt)*1.0e3)
+!     tried one suggesteed by gy niu
+      ka =  0.5*(hk(iwt)+parameters%dksat(iwt)*1.0e3)      
 
       wh_zwt  = - zwt * 1.e3                          !(mm)
       wh      = smpfz  - znode(iwt)*1.e3              !(mm)

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90
@@ -3024,7 +3024,7 @@ endif   ! croptype == 0
   
   call snow_age (parameters,dt,tg,sneqvo,sneqv,tauss,fage) 
   
-  if(cosz <= 0) goto 100
+  if(cosz <= 0) 
 
 ! weight reflectance/transmittance by lai and sai
 
@@ -3044,6 +3044,8 @@ endif   ! croptype == 0
      call snowalb_class (parameters,nband,qsnow,dt,alb,albold,albsnd,albsni,iloc,jloc)
      albold = alb
   end if
+
+100 continue
 
 ! ground surface albedo
 
@@ -9143,10 +9145,6 @@ zolmax = xkrefsqr / sqrt(xkzo)   ! maximum z/L
 
 ! recharge rate qin to groundwater
 
-!      ka  = hk(iwt)
-! harmonic average, c.he changed based on gy niu's update
-!      ka  = 2.0*(hk(iwt)*parameters%dksat(iwt)*1.0e3) / (hk(iwt)+parameters%dksat(iwt)*1.0e3)
-!     tried one suggesteed by gy niu
       ka =  0.5*(hk(iwt)+parameters%dksat(iwt)*1.0e3)      
 
       wh_zwt  = - zwt * 1.e3                          !(mm)

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90
@@ -3024,7 +3024,7 @@ endif   ! croptype == 0
   
   call snow_age (parameters,dt,tg,sneqvo,sneqv,tauss,fage) 
   
-  if(cosz <= 0) 
+  if(cosz > 0) 
 
 ! weight reflectance/transmittance by lai and sai
 
@@ -3044,8 +3044,7 @@ endif   ! croptype == 0
      call snowalb_class (parameters,nband,qsnow,dt,alb,albold,albsnd,albsni,iloc,jloc)
      albold = alb
   end if
-
-100 continue
+  end if
 
 ! ground surface albedo
 


### PR DESCRIPTION
Changes from @RuiyuSun and @HelinWei-NOAA. 

This PR addresses several key issues identified in the HRv4 and UFS/Noah-MP models, focusing on radiative flux biases, soil thermal conductivity, and evapotranspiration improvements. The goal of these updates is to enhance model performance and better align simulations with observed data.

1. Cloud/Radiation adjustments:

- To reduce the high bias in downward shortwave (DSW) radiative flux over land, the cloud number concentration over land has been increased from 100/cm³ to 150/cm³.
- The convective cloud ice radius in radiation has been reduced from 50 µm to 25 µm.
- The [2020 summer test results](https://www.emc.ncep.noaa.gov/gmb/rsun/HRv4allsNtc150/) (HRv4Ntc100) show a reduction in the high DSW bias over land and a corresponding reduction in the low bias of upward shortwave (SW) radiative flux at the top of the atmosphere (TOA).

2. Soil thermal conductivity enhancement:

- A persistent nighttime and early morning warm surface temperature bias remains in both the GFS/Noah and UFS/Noah-MP models. This is partly due to overlooking the influence of soil organic matter (SOM) on soil thermal conductivity.
- By incorporating a lookup table developed from the PNNL soil carbon dataset and VIIRS surface type data, the effects of SOM on soil thermal properties have been accounted for.
- [Tests](https://www.emc.ncep.noaa.gov/mmb/gcp/gfs/hr5/) show that including SOM results in better simulation of ground heat flux, reducing heat storage in the soil during the day, and mitigating the nighttime warm bias, particularly over the Great Plains.

3. Evapotranspiration adjustment:

- The aquifer hydraulic conductivity has been updated to use the algorithm average rather than the harmonic average. This increases the amount of water uptake by the soil layer, improving evapotranspiration modeling.

4. Bug Fixes:
- Snow aging at night: Fixed an issue to allow snow aging to occur at night, ensuring more realistic snow dynamics.
- Unit correction for potential evaporation: Corrected the unit for potential evaporation from W/m² to mm/s to ensure proper unit consistency and accuracy in the model. See this change in [https://github.com/NOAA-EMC/fv3atm/pull/903](https://github.com/NOAA-EMC/fv3atm/pull/903).
- Address https://github.com/NCAR/ccpp-physics/pull/1091

