### PR TITLE
wet() bug fix and workaround for bad tsfco

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.F90
@@ -24,7 +24,7 @@ contains
                                  flag_cice, cplflx, cplice, cplwav2atm, lsm, lsm_ruc,                                     &
                                  landfrac, lakefrac, lakedepth, oceanfrac, frland,                                        &
                                  dry, icy, lake, use_lake_model, wet, hice, cice, zorlo, zorll, zorli,                    &
-                                 snowd,            snowd_lnd, snowd_ice, tprcp, tprcp_wat,                                &
+                                 snowd,            snowd_lnd, snowd_ice, tprcp, tprcp_wat, tgrs1,                         &
                                  tprcp_lnd, tprcp_ice, uustar, uustar_wat, uustar_lnd, uustar_ice,                        &
                                  weasd,            weasd_lnd, weasd_ice, ep1d_ice, tsfc, tsfco, tsfcl, tsfc_wat,          &
                                            tisfc, tsurf_wat, tsurf_lnd, tsurf_ice,                                        &
@@ -45,6 +45,7 @@ contains
       real(kind=kind_phys), dimension(:), intent(in   )  :: snowd, tprcp, uustar, weasd, qss, tisfc
 
       real(kind=kind_phys), dimension(:), intent(inout)  :: tsfc, tsfco, tsfcl
+      real(kind=kind_phys), dimension(:), intent(inout)  :: tgrs1
       real(kind=kind_phys), dimension(:), intent(inout)  :: snowd_lnd, snowd_ice, tprcp_wat,            &
                     tprcp_lnd, tprcp_ice, tsfc_wat, tsurf_wat,tsurf_lnd, tsurf_ice,                     &
                     uustar_wat, uustar_lnd, uustar_ice, weasd_lnd, weasd_ice,                           &
@@ -179,6 +180,13 @@ contains
                 else
                   if (icy(i)) tsfco(i) = max(tisfc(i), tgice)
                 endif
+              else
+                wet(i) = .false. ! no open ocean
+              endif
+              if(wet(i) .and. tsfco(i) < 0) then
+                1013 format('using tgrs1 instead of bad tsfco(i=',I0,')=',E20.12,' slmsk(i)=',E12.7,' cice(i)=',E12.7,' islmsk(i)=',I0,' islmsk_cice(i)=',I0,' oceanfrac(i)=',E12.7,' cplice=',L1,' icy(i)=',L1,' cplflx=',L1)
+                write(0,1013) i,tsfco(i),slmsk(i),cice(i),islmsk(i),islmsk_cice(i),oceanfrac(i),cplice,icy(i),cplflx
+                tsfco(i) = tgrs1(i)
               endif
             else ! Not ocean and not land
               is_clm = lkm>0 .and. iopt_lake==iopt_lake_clm .and. use_lake_model(i)>0

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_pre.meta
@@ -223,6 +223,14 @@
   type = real
   kind = kind_phys
   intent = inout
+[tgrs1]
+  standard_name = air_temperature_at_surface_adjacent_layer
+  long_name = mean temperature at lowest model layer
+  units = K
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = in
 [tprcp]
   standard_name = nonnegative_lwe_thickness_of_precipitation_amount_on_dynamics_timestep
   long_name = total precipitation amount in each time step


### PR DESCRIPTION
Fixes this problem:

- https://github.com/ufs-community/ufs-weather-model/issues/2547

It was caused by missing values (-1e+20) for sea surface temperature on `wet` points in input data. (`Wet` points are points where the CCPP `wet` array is true, thus indicating the surface is at least partly water.) There's a bug fix and a workaround:

1. Bug fix: In certain situations, the `wet` array can be mistakenly true when it should be false due to the location being 100% ice. An "else" statement corrects this.
2. Workaround: If the input sea surface temperatures (tsfco) are invalid on a `wet` point, the lowest model level temperature is used instead.

There is no other temperature available on those points that can reasonably be used as a sea surface temperature. The lowest model level temperature may not be a perfect analogue for the sea surface temperature, but it'll be more realistic than -1E+20 K.