### PR TITLE
 fixed restart not producing issue 2588 using MERRA2 climatology

### DIFF
--- a/physics/MP/Morrison_Gettelman/aerinterp.F90
+++ b/physics/MP/Morrison_Gettelman/aerinterp.F90
@@ -331,17 +331,12 @@ contains
 #ifdef DEBUG
         if (me == master) write(*,*)"read in a new month MERRA2", n2
 #endif
-        DO ii = 1, ntrcaerm
-          do j = jamin, jamax
-            do k = 1, levsaer
-              do i = iamin, iamax
-                aerin(i,j,k,ii,1) = aerin(i,j,k,ii,2)
-              enddo   !i-loop (lon)
-            enddo     !k-loop (lev)
-          enddo       !j-loop (lat)
-        ENDDO         ! ii-loop (ntracaerm)
 !! ===================================================================
+        call read_netfaer(n1, iflip, 1, errmsg, errflg)
+        if(errflg/=0) return
         call read_netfaer(n2, iflip, 2, errmsg, errflg)
+        if(errflg/=0) return
+!! ===================================================================
         n1sv=n1
         n2sv=n2
       end if


### PR DESCRIPTION
This pull request fix the issue #2588: https://github.com/ufs-community/ufs-weather-model/issues/2588#issuecomment-2682166742. A few lines of changes in aerosol interpolation code to make sure both the continuous running and restart running read the MERRA2 files in the same way. PRs https://github.com/ufs-community/ufs-weather-model/pull/2625 and https://github.com/NOAA-EMC/fv3atm/pull/933 are need for this PR enter the trunk.