### PR TITLE
fix the RRTMGP cloud scheme to be consistent with those in RRTMG

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_mp.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_mp.F90
@@ -743,14 +743,10 @@ contains
           cld_swp(iCol,iLay)  = max(0., cld_condensate(iCol,iLay,4) * tem1 * deltaP)
        
           ! Xu-Randall (1996) cloud-fraction. **Additionally, Conditioned on relative-humidity**
-          if (present(cond_cfrac_onRH) .and. relhum(iCol,iLay) > 0.99) then
-             cld_frac(iCol,iLay) = 1._kind_phys
-          else
-             cld_mr = cld_condensate(iCol,iLay,1) + cld_condensate(iCol,iLay,2) +  &
-                  cld_condensate(iCol,iLay,3) + cld_condensate(iCol,iLay,4)
-             cld_frac(iCol,iLay) = cld_frac_XuRandall(p_lay(iCol,iLay),            &
-                  qs_lay(iCol,iLay), relhum(iCol,iLay), cld_mr, alpha0)
-          endif
+          cld_mr = cld_condensate(iCol,iLay,1) + cld_condensate(iCol,iLay,2) +  &
+               cld_condensate(iCol,iLay,3) + cld_condensate(iCol,iLay,4)
+          cld_frac(iCol,iLay) = cld_frac_XuRandall(p_lay(iCol,iLay),            &
+               qs_lay(iCol,iLay), relhum(iCol,iLay), cld_mr, alpha0)
        enddo
     enddo
 
@@ -802,14 +798,18 @@ contains
        lambda = 0.50, & !
        P      = 0.25
 
-    clwt = 1.0e-6 * (p_lay*0.001)
+    clwt = 1.0e-8 * (p_lay*0.001)
     if (cld_mr > clwt) then
-       onemrh = max(1.e-10, 1.0 - relhum)
-       tem1   = alpha / min(max((onemrh*qs_lay)**lambda,0.0001),1.0)
-       tem2   = max(min(tem1*(cld_mr - clwt), 50.0 ), 0.0 )
-       tem3   = sqrt(sqrt(relhum)) ! This assumes "p" = 0.25. Identical, but cheaper than relhum**p
-       !
-       cld_frac_XuRandall = max( tem3*(1.0-exp(-tem2)), 0.0 )
+       if(relhum > 0.99) then
+          cld_frac_XuRandall = 1.
+       else
+          onemrh = max(1.e-10, 1.0 - relhum)
+          tem1   = alpha / min(max((onemrh*qs_lay)**lambda,0.0001),1.0)
+          tem2   = max(min(tem1*(cld_mr - clwt), 50.0 ), 0.0 )
+          tem3   = sqrt(sqrt(relhum)) ! This assumes "p" = 0.25. Identical, but cheaper than relhum**p
+          !
+          cld_frac_XuRandall = max( tem3*(1.0-exp(-tem2)), 0.0 )
+      endif
     else
        cld_frac_XuRandall = 0.0
     endif

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_mp.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_mp.F90
@@ -743,10 +743,10 @@ contains
           cld_swp(iCol,iLay)  = max(0., cld_condensate(iCol,iLay,4) * tem1 * deltaP)
        
           ! Xu-Randall (1996) cloud-fraction. **Additionally, Conditioned on relative-humidity**
-          cld_mr = cld_condensate(iCol,iLay,1) + cld_condensate(iCol,iLay,2) +  &
+          cld_mr = cld_condensate(iCol,iLay,1) + cld_condensate(iCol,iLay,2) +          &
                cld_condensate(iCol,iLay,3) + cld_condensate(iCol,iLay,4)
-          cld_frac(iCol,iLay) = cld_frac_XuRandall(p_lay(iCol,iLay),            &
-               qs_lay(iCol,iLay), relhum(iCol,iLay), cld_mr, alpha0)
+          cld_frac(iCol,iLay) = cld_frac_XuRandall(p_lay(iCol,iLay),                    &
+               qs_lay(iCol,iLay), relhum(iCol,iLay), cld_mr, alpha0, cond_cfrac_onRH)
        enddo
     enddo
 
@@ -777,9 +777,12 @@ contains
 !> This function computes the cloud-fraction following
 !! Xu-Randall(1996) \cite xu_and_randall_1996 
 !!
-  function cld_frac_XuRandall(p_lay, qs_lay, relhum, cld_mr, alpha)
+  function cld_frac_XuRandall(p_lay, qs_lay, relhum, cld_mr, alpha, cond_cfrac_onRH)
     implicit none
     ! Inputs
+   logical, intent(in), optional :: &
+       cond_cfrac_onRH    ! If true, cloud-fracion set to unity when rh>99%
+
     real(kind_phys), intent(in) :: &
        p_lay,    & !< Pressure (Pa)
        qs_lay,   & !< Saturation vapor-pressure (Pa)
@@ -800,7 +803,7 @@ contains
 
     clwt = 1.0e-8 * (p_lay*0.001)
     if (cld_mr > clwt) then
-       if(relhum > 0.99) then
+       if(present(cond_cfrac_onRH) .and. relhum > 0.99) then
           cld_frac_XuRandall = 1.
        else
           onemrh = max(1.e-10, 1.0 - relhum)


### PR DESCRIPTION
This PR fix the cloud cover calculations in the RRTMGP scheme. The RRTMGP has a very large high cloud cover compared to those from the RRTMG.  After the fix, the cloud cover differences between those two schemes for all levels are significantly reduced.
The Google document is here:
https://docs.google.com/presentation/d/1D1e1zcDUo0tCCyybcP3fGhYoe-3j26muP6GxKUl0L_o/edit?slide=id.g342273d85cd_0_79#slide=id.g342273d85cd_0_79