### PR TITLE
Set zero for canopy liquid and canopy ice over glacier in NoahMP

### DIFF
--- a/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
+++ b/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
@@ -1206,8 +1206,8 @@ end subroutine noahmpdrv_timestep_init
 
         snow_cover_fraction    = 1.0
         temperature_leaf       = undefined  
-        canopy_ice             = undefined
-        canopy_liquid          = undefined
+        canopy_ice             = 0.0
+        canopy_liquid          = 0.0
         vapor_pres_canopy_air  = undefined
         temperature_canopy_air = undefined
         canopy_wet_fraction    = undefined


### PR DESCRIPTION
Failure of some UFS prototypes (e.g., GEFS) results from the "bad" canopy water used by the Noah-MP land surface model. In fact, canopy water is sum of canopy liquid and canopy ice in the Noah-MP, which is available only at the vegetation grids and there is no canopy variable at the glacier grids. Therefore, it doesn't really matter what canopy variables including canopy water are at initial time or at the forecast time over the glacier, so canopy liquid or canopy ice is set with a missing values (9.99e20_kind_phys).

However, some other processes such as UFS cold starts, outputs, restart and CHGRES steps, sometimes do not exclude 'glacier fraction' when processing canopy variables, and assign unrealistically canopy values over non-glacier points.

As one of options, set canopy liquid=0.0 and canopy ice=0.0 in Noah-MP, so that it avoids failure of some UFS prototypes (e.g., GEFS) results from the "bad" canopy water used by the Noah-MP land surface model.

##ISSUE
Fixes https://github.com/NCAR/ccpp-physics/pull/272: https://github.com/ufs-community/ccpp-physics/issues/272