### PR TITLE
Bug fix in radiation aerosols to fix restart reproducibility issue with NEPTUNE model

### DIFF
--- a/physics/Radiation/radiation_aerosols.f
+++ b/physics/Radiation/radiation_aerosols.f
@@ -2901,7 +2901,7 @@
 !  ---  map grid in longitude direction, lon from 0 to 355 deg resolution
 
 !       print *,' Seeking lon index for point i =',i
-        i3 = i1
+        i3 = 1
         lab_do_IMXAE : do while ( i3 <= IMXAE )
           tmp1 = dltg * (i3 - 1)
           dtmp = alon(i) - tmp1
@@ -2942,7 +2942,7 @@
 !  ---  map grid in latitude direction, lat from 90n to 90s in 5 deg resolution
 
 !       print *,' Seeking lat index for point i =',i
-        j3 = j1
+        j3 = 1
         lab_do_JMXAE : do while ( j3 <= JMXAE )
           tmp2 = 90.0 - dltg * (j3 - 1)
           dtmp = tmp2 - alat(i)


### PR DESCRIPTION
## Description of Changes:

Change indices `i3` and `j3` in routine `aer_property` in `radiation_aerosols.f` to run from 1 instead of `i1`/`j1` to fix a restart reproducibility issue with NEPTUNE. See https://github.com/NCAR/ccpp-physics/issues/1140 for more information.

## Tests Conducted:

- [x] Without this change, NEPTUNE restarts are not reproducible (tested in NEPTUNE)
- [x] Ran the full UFS regression tests on Hera and everything was b4b with the previous baseline

## Dependencies:

No parents created. This PR will be combined with something else, I assume.

## Documentation:

See issue.

## Issue (optional):

This will eventually resolve https://github.com/NCAR/ccpp-physics/issues/1140 once it gets merged into NCAR main.

## Contributors (optional):

All credits go to @areinecke for this work, I am just the messenger.