### PR TITLE
Draft PR for combining (will update title when finished)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,12 @@ target_include_directories(ccpp_physics PUBLIC
 target_link_libraries(ccpp_physics PRIVATE MPI::MPI_Fortran)
 target_link_libraries(ccpp_physics PUBLIC w3emc::w3emc_d
                                           sp::sp_d
-                                          NetCDF::NetCDF_Fortran)
+                                          NetCDF::NetCDF_Fortran
+				             )
+#add FMS for FV3 only
+if(FV3)
+  target_link_libraries(ccpp_physics PUBLIC fms)
+endif()
 
 # Define where to install the library
 install(TARGETS ccpp_physics


### PR DESCRIPTION
- Removal of gfdl_parse_tracers file in ccpp-physics 
-- Since GFS_typedefs.F90 compilation seems to be controlled through the CMakeLists.txt file in ccpp/physics, if we need to use the FMS version of get_tracer_index in GFS_typedefs, we need to add FMS as an included library in CMakeLists.txt for the FV3 only