### PR TITLE
Tidy up more compiler warnings

### DIFF
--- a/physics/GWD/cires_ugwpv1_oro.F90
+++ b/physics/GWD/cires_ugwpv1_oro.F90
@@ -222,7 +222,8 @@ contains
         dusfc(i)    = 0.0
         dvsfc(i)    = 0.0
         ipt(i) = 0 
-      enddo     
+      enddo
+      zlwb(:) = 0.0
  
 ! ----  for lm and gwd calculation points
 !cires_ugwp_initialize.F90:      real, parameter :: hpmax=2400.0, hpmin=25.0  

--- a/physics/GWD/cires_ugwpv1_triggers.F90
+++ b/physics/GWD/cires_ugwpv1_triggers.F90
@@ -298,7 +298,7 @@ contains
         if (dmax >= tlim_okw) kex = kex+1 
         do k=klow+1, ktop
           dtot = abs(trig_okw(i,k))
-          if (dtot >= tlim_fgf ) kex = kex+1 
+          if (dtot >= tlim_okw ) kex = kex+1 
           if ( dtot >  dmax) then
             klev(i) = k
             dmax =  dtot

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
@@ -3093,8 +3093,11 @@
               enddo
             enddo
           else
-            do i=1,imax
-              data(imax-i+1,jj) = work(i,j)
+            do j=1,jmax
+              jj = jmax - j + 1
+              do i=1,imax
+                data(imax-i+1,jj) = work(i,j)
+              enddo
             enddo
           endif
         else


### PR DESCRIPTION
Address remaining CCPP physics warnings in https://github.com/ufs-community/ufs-weather-model/issues/2703 of
```
.../ufs-weather-model/FV3/ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F:3097:72:
 3097 |               data(imax-i+1,jj) = work(i,j)
Warning: 'jj' may be used uninitialized [-Wmaybe-uninitialized]

.../ufs-weather-model/FV3/ccpp/physics/physics/GWD/cires_ugwpv1_triggers.F90(301): warning #6717: This name has not been given an explicit type.   [TLIM_FGF]
          if (dtot >= tlim_fgf ) kex = kex+1

.../ufs-weather-model/FV3/ccpp/physics/physics/GWD/cires_ugwpv1_oro.F90(14): warning #6843: A dummy argument with an explicit INTENT(OUT) declaration is not given an explicit value.   [ZLWB]
                      zobl, zlwb, zogw, tau_ogw, dudt_ogw, dvdt_ogw,      &
```

ufs-weather-model regression tests pass bit-for-bit on hera. As for the changes:
1. I'm mostly guessing at the "fix" for jj based on neighboring logic. I don't think any RTs exercise dlat > 0.0, dlon <= 0.0 for sfcsub.F
2. tlim_fgf is defined above this in get_spectra_tau_nstgw but not in get_spectra_tau_okw
3. Setting zlwb=0 is as in code and https://github.com/ufs-community/ccpp-physics/pull/149