### PR TITLE
Fix setting of land mask in sfcsub.F

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
@@ -7947,7 +7947,7 @@ cjfe
                   ! points.  so for efficiency, don't have fixrdc try to
                   ! find a value at landice points as defined by the vet type (vet).
               allocate(slmask_noice(len))
-              slmask_noice=1.0
+              slmask_noice = slmskl
               do i = 1, len
                 if (nint(vet(i)) < 1 .or.
      &              nint(vet(i)) == landice_cat) then


### PR DESCRIPTION
## Description of Changes:
Fix the setting of the land mask used in interpolating GLDAS soil data to the model grid. For a complete description, see #300,

## Tests Conducted:
All regression tests were run on WCOSS2 and passed.

Tests were conducted in a GFS v17 parallel: https://github.com/NOAA-EMC/GFS/issues/16#issuecomment-3070539064

## Dependencies:
None.

## Documentation:
N/A

## Issue (optional):
Fixes #300.