### PR TITLE
Introduce tuning parameter for convective cloud liquid for GFSv17/GEFSv13/SFSv1

### DIFF
--- a/.github/workflows/ci_fv3_ccpp_prebuild.yml
+++ b/.github/workflows/ci_fv3_ccpp_prebuild.yml
@@ -54,4 +54,4 @@ jobs:
       run: |
         cd /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/ccpp/
         mkdir -p /home/runner/work/ccpp-physics/ccpp-physics/fv3atm/bin/ccpp/physics/physics/
-        ./framework/scripts/ccpp_prebuild.py --config config/ccpp_prebuild_config.py
+        ./framework/scripts/ccpp_prebuild.py --config config/ccpp_prebuild_config_fv3.py

--- a/physics/CONV/SAMF/samfdeepcnv.f
+++ b/physics/CONV/SAMF/samfdeepcnv.f
@@ -82,7 +82,7 @@
      &    islimsk,garea,dot,ncloud,hpbl,ud_mf,dd_mf,dt_mf,cnvw,cnvc,    &
      &    QLCN, QICN, w_upi, cf_upi, CNV_MFD,                           &
      &    CNV_DQLDT,CLCN,CNV_FICE,CNV_NDROP,CNV_NICE,mp_phys,mp_phys_mg,&
-     &    clam,c0s,c1,betal,betas,evef,pgcon,asolfac,                   &
+     &    clam,c0s,c1,betal,betas,evef,pgcon,asolfac,cscale,            &
      &    do_ca, ca_closure, ca_entr, ca_trigger, nthresh,ca_deep,      &
      &    rainevap,sigmain,sigmaout,omegain,omegaout,betadcu,betamcu,   &
      &    betascu,maxMF,do_mynnedmf,sigmab_coldstart,errmsg,errflg)
@@ -97,7 +97,7 @@
       integer, intent(in)  :: islimsk(:)
       real(kind=kind_phys), intent(in) :: cliq, cp, cvap, eps, epsm1,   &
      &   fv, grav, hvap, rd, rv, t0c
-      real(kind=kind_phys), intent(in) ::  delt
+      real(kind=kind_phys), intent(in) ::  delt, cscale
       real(kind=kind_phys), intent(in) :: psp(:), delp(:,:),            &
      &   prslp(:,:),  garea(:), hpbl(:), dot(:,:), phil(:,:) 
       real(kind=kind_phys), dimension(:), intent(in) :: fscav
@@ -219,7 +219,7 @@ cj
 !  parameters for prognostic sigma closure                                                                                                                                                      
       real(kind=kind_phys) omega_u(im,km),zdqca(im,km),tmfq(im,km),
      &     omegac(im),zeta(im,km),dbyo1(im,km),sigmab(im),qadv(im,km),
-     &     sigmaoutx(im),tentr(im,km)
+     &     tentr(im,km)
       real(kind=kind_phys) gravinv,invdelt,sigmind,sigminm,sigmins
       parameter(sigmind=0.01,sigmins=0.03,sigminm=0.01)
       logical flag_shallow, flag_mid
@@ -3467,14 +3467,6 @@ c
         endif
       enddo
 c
-!
-      if(progsigma)then
-         do i = 1, im
-            sigmaoutx(i)=max(sigmaout(i,1),0.0)
-            sigmaoutx(i)=min(sigmaoutx(i),1.0)
-         enddo
-      endif
-c
 !> - Calculate convective cloud water.
       do k = 1, km
          do i = 1, im
@@ -3482,9 +3474,9 @@ c
                if (k >= kbcon(i) .and. k < ktcon(i)) then
                   cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
                   if(progsigma)then
-                     cnvw(i,k) = cnvw(i,k) * sigmaoutx(i)
+                     cnvw(i,k) = cnvw(i,k) * cscale 
                   else
-                     cnvw(i,k) = cnvw(i,k) * sigmagfm(i)
+                     cnvw(i,k) = cnvw(i,k) * cscale
                   endif
                endif
             endif

--- a/physics/CONV/SAMF/samfdeepcnv.meta
+++ b/physics/CONV/SAMF/samfdeepcnv.meta
@@ -189,8 +189,8 @@
   kind = kind_phys
   intent = in
 [cscale]
-  standard_name = scaling_conv_cloud_water_in_sas
-  long_name = scaling parameter for conv cloud water
+  standard_name = multiplicative_tuning_parameter_for_convective_cloud_water
+  long_name = multiplicative tuning parameter for convective cloud_water
   units = none
   dimensions = ()
   type = real

--- a/physics/CONV/SAMF/samfdeepcnv.meta
+++ b/physics/CONV/SAMF/samfdeepcnv.meta
@@ -188,6 +188,14 @@
   type = real
   kind = kind_phys
   intent = in
+[cscale]
+  standard_name = scaling_conv_cloud_water_in_sas
+  long_name = scaling parameter for conv cloud water
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
 [delt]
   standard_name = timestep_for_physics
   long_name = physics time step

--- a/physics/CONV/SAMF/samfshalcnv.f
+++ b/physics/CONV/SAMF/samfshalcnv.f
@@ -55,7 +55,7 @@
      &     t0c,delt,ntk,ntr,delp,first_time_step,restart,               & 
      &     tmf,qmicro,progsigma,progomega,                              &
      &     prslp,psp,phil,tkeh,qtr,prevsq,q,q1,t1,u1,v1,fscav,          &
-     &     rn,kbot,ktop,kcnv,islimsk,garea,                             &
+     &     rn,kbot,ktop,kcnv,islimsk,garea,cscale,                      &
      &     dot,ncloud,hpbl,ud_mf,dt_mf,cnvw,cnvc,                       &
      &     clam,c0s,c1,evef,pgcon,asolfac,hwrf_samfshal,                & 
      &     sigmain,sigmaout,omegain,omegaout,betadcu,betamcu,betascu,   &
@@ -71,7 +71,7 @@
       real(kind=kind_phys), intent(in) :: cliq, cp, cvap,               &
      &   eps, epsm1, fv, grav, hvap, rd, rv, t0c, betascu, betadcu,     &
      &   betamcu
-      real(kind=kind_phys), intent(in) ::  delt
+      real(kind=kind_phys), intent(in) ::  delt, cscale
       real(kind=kind_phys), intent(in) :: psp(:), delp(:,:),            &
      &   prslp(:,:), garea(:), hpbl(:), dot(:,:), phil(:,:),            &
      &   tmf(:,:,:), q(:,:)
@@ -167,7 +167,7 @@ cc
 !  parameters for prognostic sigma closure
       real(kind=kind_phys) omega_u(im,km),zdqca(im,km),tmfq(im,km),
      &                     omegac(im),zeta(im,km),dbyo1(im,km),
-     &                     sigmab(im),qadv(im,km),sigmaoutx(im)
+     &                     sigmab(im),qadv(im,km)
       real(kind=kind_phys) gravinv,dxcrtas,invdelt,sigmind,sigmins,
      &                     sigminm
       logical flag_shallow,flag_mid
@@ -2441,13 +2441,6 @@ cj
         endif
       enddo
 c
-      if(progsigma)then
-         do i = 1, im
-            sigmaoutx(i)=max(sigmaout(i,1),0.0)
-            sigmaoutx(i)=min(sigmaoutx(i),1.0)
-         enddo
-      endif
-      
 c     convective cloud water
       do k = 1, km
          do i = 1, im
@@ -2455,9 +2448,9 @@ c     convective cloud water
                if (k >= kbcon(i) .and. k < ktcon(i)) then
                   cnvw(i,k) = cnvwt(i,k) * xmb(i) * dt2
                   if (progsigma) then
-                     cnvw(i,k) = cnvw(i,k) * sigmaoutx(i)
+                     cnvw(i,k) = cnvw(i,k) * cscale
                   else
-                     cnvw(i,k) = cnvw(i,k) * sigmagfm(i)
+                     cnvw(i,k) = cnvw(i,k) * cscale
                   endif
                endif
             endif

--- a/physics/CONV/SAMF/samfshalcnv.meta
+++ b/physics/CONV/SAMF/samfshalcnv.meta
@@ -189,8 +189,8 @@
   kind = kind_phys
   intent = in
 [cscale]
-  standard_name = scaling_conv_cloud_water_in_sas
-  long_name = scaling parameter for conv cloud water
+  standard_name = multiplicative_tuning_parameter_for_convective_cloud_water
+  long_name = multiplicative tuning parameter for convective cloud water
   units = none
   dimensions = ()
   type = real

--- a/physics/CONV/SAMF/samfshalcnv.meta
+++ b/physics/CONV/SAMF/samfshalcnv.meta
@@ -188,6 +188,14 @@
   type = real
   kind = kind_phys
   intent = in
+[cscale]
+  standard_name = scaling_conv_cloud_water_in_sas
+  long_name = scaling parameter for conv cloud water
+  units = none
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
 [delt]
   standard_name = timestep_for_physics
   long_name = physics time step


### PR DESCRIPTION
## Description of Changes:
The interaction between convective clouds and radiation is degraded in later prototypes of GFSv17 (C1152) and GEFSv13 (C384) due to a scaling of convective cloud liquid in saSAS passed to radiation. For SFSv1 (C192-C96) the scaling is necessary to prevent a major cold bias in SST. Because of the sensitivity to application/resolution, and the large impact the convective cloud liquid has on the surface energy balance/MJO prediction/and SST bias we here propose to include it instead as a tunable paramter. This replaces the current scaling by updraft area fraction.

## Tests Conducted:
GFSv17, GEFSv13 and SFSv1 retrospective runs. 

## Dependencies:

## Issue (optional):
https://github.com/ufs-community/ufs-weather-model/issues/2871

## Contributors (optional):
@JongilHan66 @yangfanglin @RuiyuSun 
