### PR TITLE
Glacier modifications in NoahMP to address GFSv17 biases

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.F90
@@ -533,10 +533,8 @@
                  endif
 
                  if (vegtyp == 15) then                      ! land ice in MODIS/IGBP
-                   if (weasd(ix) < 0.1_kind_phys) then
-                     weasd(ix) = 0.1_kind_phys
-                     snd       = 0.01_kind_phys
-                   endif
+                   weasd(ix) = 600.0_kind_phys   ! 600mm SWE for glacier
+                   snd       = 2.0_kind_phys     ! 2m snow depth for glacier
                  endif
 
                  if (snd < 0.025_kind_phys ) then

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
@@ -2736,19 +2736,28 @@ end if   ! opt_gla == 1
 ! local
 
   integer :: newnode            !< 0-no new layers, 1-creating new layers
+  real (kind=kind_phys) :: snowhin_adj  !< new snow depth rate with minimum adj [m/s]
+  real (kind=kind_phys) :: qsnow_adj    !< new snow water rate with minimum adj [mm/s]
+  real (kind=kind_phys) :: snowh_def    !< snow depth deficit this timestep 
+  real (kind=kind_phys), parameter :: snow_depth_min = 0.2  ! 20cm
 ! ----------------------------------------------------------------------
     newnode  = 0
 
+    snowh_def = max(0.0,snow_depth_min - (snowh + snowhin*dt))  ! if > 0 add more snow
+
+    snowhin_adj = snowhin + snowh_def/dt
+    qsnow_adj   = qsnow   + snowh_def*120.0/dt  ! assume new snow density = 120
+
 ! shallow snow / no layer
 
-    if(isnow == 0 .and. qsnow > 0.)  then
-      snowh = snowh + snowhin * dt
-      sneqv = sneqv + qsnow * dt
+    if(isnow == 0 .and. qsnow_adj > 0.)  then
+      snowh = snowh + snowhin_adj * dt
+      sneqv = sneqv + qsnow_adj * dt
     end if
 
 ! creating a new layer
  
-    if(isnow == 0  .and. qsnow>0. .and. snowh >= 0.025) then
+    if(isnow == 0  .and. qsnow_adj>0. .and. snowh >= 0.025) then
       isnow    = -1
       newnode  =  1
       dzsnso(0)= snowh
@@ -2760,9 +2769,9 @@ end if   ! opt_gla == 1
 
 ! snow with layers
 
-    if(isnow <  0 .and. newnode == 0 .and. qsnow > 0.) then
-         snice(isnow+1)  = snice(isnow+1)   + qsnow   * dt
-         dzsnso(isnow+1) = dzsnso(isnow+1)  + snowhin * dt
+    if(isnow <  0 .and. newnode == 0 .and. qsnow_adj > 0.) then
+         snice(isnow+1)  = snice(isnow+1)   + qsnow_adj   * dt
+         dzsnso(isnow+1) = dzsnso(isnow+1)  + snowhin_adj * dt
     endif
 
 ! ----------------------------------------------------------------------

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
@@ -2650,6 +2650,23 @@ end if   ! opt_gla == 1
                           ponding1 ,ponding2 ,fsh    ,                 & !inout
                           qsnbot )                                       !out
 
+!reset the glacier to 2m depth with 600mm SWE
+
+   isnow = -3
+   snice(-2) = 15.0
+   snice(-1) = 60.0
+   snice( 0) = 525.0
+   snliq(-2) = 0.0
+   snliq(-1) = 0.0
+   snliq( 0) = 0.0
+   if(stc( 0) < 100.0) stc( 0) = stc( 1)  ! if the temperature is missing,
+   if(stc(-1) < 100.0) stc(-1) = stc( 0)  !  set to layer below
+   if(stc(-2) < 100.0) stc(-2) = stc(-1)  !  should not be necessary
+   dzsnso(-2)= 0.05
+   dzsnso(-1)= 0.20
+   dzsnso( 0)= 1.75
+   sneqv = 600.0
+
 !set empty snow layers to zero
 
    do iz = -nsnow+1, isnow
@@ -2736,28 +2753,19 @@ end if   ! opt_gla == 1
 ! local
 
   integer :: newnode            !< 0-no new layers, 1-creating new layers
-  real (kind=kind_phys) :: snowhin_adj  !< new snow depth rate with minimum adj [m/s]
-  real (kind=kind_phys) :: qsnow_adj    !< new snow water rate with minimum adj [mm/s]
-  real (kind=kind_phys) :: snowh_def    !< snow depth deficit this timestep 
-  real (kind=kind_phys), parameter :: snow_depth_min = 0.2  ! 20cm
 ! ----------------------------------------------------------------------
     newnode  = 0
 
-    snowh_def = max(0.0,snow_depth_min - (snowh + snowhin*dt))  ! if > 0 add more snow
-
-    snowhin_adj = snowhin + snowh_def/dt
-    qsnow_adj   = qsnow   + snowh_def*120.0/dt  ! assume new snow density = 120
-
 ! shallow snow / no layer
 
-    if(isnow == 0 .and. qsnow_adj > 0.)  then
-      snowh = snowh + snowhin_adj * dt
-      sneqv = sneqv + qsnow_adj * dt
+    if(isnow == 0 .and. qsnow > 0.)  then
+      snowh = snowh + snowhin * dt
+      sneqv = sneqv + qsnow * dt
     end if
 
 ! creating a new layer
  
-    if(isnow == 0  .and. qsnow_adj>0. .and. snowh >= 0.025) then
+    if(isnow == 0  .and. qsnow>0. .and. snowh >= 0.025) then
       isnow    = -1
       newnode  =  1
       dzsnso(0)= snowh
@@ -2769,9 +2777,9 @@ end if   ! opt_gla == 1
 
 ! snow with layers
 
-    if(isnow <  0 .and. newnode == 0 .and. qsnow_adj > 0.) then
-         snice(isnow+1)  = snice(isnow+1)   + qsnow_adj   * dt
-         dzsnso(isnow+1) = dzsnso(isnow+1)  + snowhin_adj * dt
+    if(isnow <  0 .and. newnode == 0 .and. qsnow > 0.) then
+         snice(isnow+1)  = snice(isnow+1)   + qsnow   * dt
+         dzsnso(isnow+1) = dzsnso(isnow+1)  + snowhin * dt
     endif
 
 ! ----------------------------------------------------------------------

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
@@ -2616,7 +2616,7 @@ end if   ! opt_gla == 1
 ! local
   integer :: iz
   real (kind=kind_phys)    :: bdsnow  !< bulk density of snow (kg/m3)
-  real (kind=kind_phys),parameter :: mwd  = 100.   !< maximum water depth (mm)
+  real (kind=kind_phys),parameter :: mwd  = 600.   !< maximum water depth (mm)
 ! ----------------------------------------------------------------------
    snoflow = 0.0
    ponding1 = 0.0
@@ -2662,7 +2662,7 @@ end if   ! opt_gla == 1
 
 !to obtain equilibrium state of snow in glacier region
        
-   if(sneqv > mwd) then   ! 100 mm -> maximum water depth
+   if(sneqv > mwd) then   ! 600 mm -> maximum water depth
       bdsnow      = snice(0) / dzsnso(0)
       snoflow     = (sneqv - mwd)
       snice(0)    = snice(0)  - snoflow 

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
@@ -785,8 +785,8 @@ contains
   do iz = isnow+1, 0
 !     tksno(iz) = 3.2217e-6*bdsnoi(iz)**2.           ! stieglitz(yen,1965)
 !    tksno(iz) = 2e-2+2.5e-6*bdsnoi(iz)*bdsnoi(iz)   ! anderson, 1976
-!    tksno(iz) = 0.35                                ! constant
-    tksno(iz) = 2.576e-6*bdsnoi(iz)**2. + 0.074    ! verseghy (1991)
+    tksno(iz) = 0.35                                ! constant
+!    tksno(iz) = 2.576e-6*bdsnoi(iz)**2. + 0.074    ! verseghy (1991)
 !    tksno(iz) = 2.22*(bdsnoi(iz)/1000.)**1.88      ! douvill(yen, 1981)
   enddo
 

--- a/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
+++ b/physics/SFC_Models/Land/Noahmp/module_sf_noahmp_glacier.F90
@@ -982,8 +982,8 @@ contains
         cf1=((1.+sl1)/(1.+sl2*cosz)-sl1)
         fzen=amax1(cf1,0.)
 
-        albsni(1)=0.95*(1.-c1*fage)         
-        albsni(2)=0.65*(1.-c2*fage)        
+        albsni(1)=0.95  !*(1.-c1*fage)  ! remove aging over glaciers       
+        albsni(2)=0.65  !*(1.-c2*fage)  ! remove aging over glaciers 
 
         albsnd(1)=albsni(1)+0.4*fzen*(1.-albsni(1))    !  vis direct
         albsnd(2)=albsni(2)+0.4*fzen*(1.-albsni(2))    !  nir direct


### PR DESCRIPTION
## Description of Changes:
Testing for GFSv17 exposed temperature and albedo biases over glacier regions. There were also large differences when compared to GFSv16 (current operational) and ERA5. To address these biases, the following changes are added:
- removal of albedo aging (current approach is probably too aggressive for remote locations like Antarctica and Greenland)
- change snow thermal conductivity to be consistent with that used in non-glacier NoahMP model
- keep the snow depth and density fixed over glacier following a similar approach used in other NWP systems; this includes cold starting glaciers with 2m of snow

## Tests Conducted:
- C1152 simulation on 2025-12-02 to test performance over Antarctica
- Regression tests run on ursa

## Dependencies:
- NOAA-EMC/ufsatm#1010
- ufs-community/ufs-weather-model#2886

## Documentation:
No documentation changes required

## Contributors:
@wzzheng90 @zhichang-guo 
