### PR TITLE
Remove non-warning log write statement

### DIFF
--- a/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
+++ b/physics/SFC_Models/Land/Noahmp/noahmpdrv.F90
@@ -367,8 +367,9 @@ subroutine noahmpdrv_timestep_init (itime, fhour, delt, km,  ncols,         &
 
     deallocate(stc_updated, slc_updated)
     deallocate(mask_tile)
-  
-    write(*,'(a,i4,a,i8)') 'noahmpdrv_timestep_init rank ', Land_IAU_Control%me, ' # of cells with stc update ', nstcupd
+    
+    !Remove non-warning, non-error log write
+    !write(*,'(a,i4,a,i8)') 'noahmpdrv_timestep_init rank ', Land_IAU_Control%me, ' # of cells with stc update ', nstcupd
 
 
 end subroutine noahmpdrv_timestep_init


### PR DESCRIPTION
## Description of Changes:
This PR will remove a write statement that triggers too frequently when Land IAU is being used. Since the log statement is not a warning or an error, the message will be removed. This was done in the NoahMP repo https://github.com/NOAA-EMC/noahmp/commit/393687ef2b0139370a76320ffee3cc949e797c5e and this change will bring the `noahmpdrv` file up to what the current NOAA-EMC/noahmp repository.

## Tests Conducted:
These changes will be tested with the UFS RT suite and no changes to baselines are expected.

## Dependencies:
- None

## Documentation:
No new documentation needed

## Issue (optional):
- Closes https://github.com/ufs-community/ccpp-physics/issues/320

