### PR TITLE
CCPP metadata: relative_path --> dependencies_path

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_cloud_diagnostics.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_cloud_diagnostics.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_cloud_diagnostics
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F,Radiation/radiation_clouds.f
 
 ########################################################################

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.fv3.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_phys_time_vary
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F
   dependencies = Interstitials/UFS_SCM_NEPTUNE/gcycle.F90,Interstitials/UFS_SCM_NEPTUNE/iccn_def.F
   dependencies = Interstitials/UFS_SCM_NEPTUNE/iccninterp.F90,Interstitials/UFS_SCM_NEPTUNE/sfcsub.F

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.scm.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_phys_time_vary.scm.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_phys_time_vary
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F
   dependencies = Interstitials/UFS_SCM_NEPTUNE/iccn_def.F,Interstitials/UFS_SCM_NEPTUNE/iccninterp.F90
   dependencies = Interstitials/UFS_SCM_NEPTUNE/sfcsub.F,Radiation/mersenne_twister.f

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.fv3.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.fv3.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_rad_time_vary
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F,Radiation/mersenne_twister.f,Radiation/RRTMG/radcons.f90
 
 ########################################################################

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.mpas.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.mpas.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_rad_time_vary
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F,Radiation/mersenne_twister.f,Radiation/RRTMG/radcons.f90
 
 ########################################################################

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.scm.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rad_time_vary.scm.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_rad_time_vary
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F,Radiation/mersenne_twister.f,Radiation/RRTMG/radcons.f90
 
 ########################################################################

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_radiation_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_radiation_post.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_radiation_post
   type = scheme
-  relative_path	= ../../
+  dependencies_path	= ../../
   dependencies = hooks/machine.F,Radiation/radiation_aerosols.f
   dependencies = Radiation/RRTMG/radlw_param.f,Radiation/radiation_tools.F90,Radiation/RRTMGP/rte-rrtmgp/extensions/mo_heating_rates.F90
   dependencies = Radiation/RRTMGP/rte-rrtmgp/rte-frontend/mo_rte_kind.F90

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_radiation_surface.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_radiation_surface.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_radiation_surface
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = Radiation/radiation_surface.f
   dependencies = SFC_Models/Land/RUC/set_soilveg_ruc.F90,SFC_Models/Land/RUC/namelist_soilveg_ruc.F90
   dependencies = hooks/machine.F

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_pre.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_rrtmg_pre
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = tools/funcphys.f90,hooks/machine.F
   dependencies = MP/TEMPO/TEMPO/module_mp_tempo_params.F90,MP/TEMPO/TEMPO/module_mp_tempo_utils.F90
   dependencies = MP/Thompson/module_mp_thompson.F90,MP/Thompson/module_mp_thompson_make_number_concentrations.F90

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_setup.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmg_setup.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_rrtmg_setup
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F
   dependencies = Radiation/radiation_aerosols.f
   dependencies = Radiation/radiation_astronomy.f,Radiation/radiation_clouds.f,Radiation/radiation_gases.f

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_mp.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_mp.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_rrtmgp_cloud_mp
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F
   dependencies = Radiation/radiation_tools.F90,Radiation/radiation_clouds.f,Radiation/RRTMGP/rrtmgp_lw_cloud_optics.F90
   dependencies = MP/module_mp_radar.F90,MP/Thompson/module_mp_thompson_make_number_concentrations.F90,MP/Thompson/module_mp_thompson.F90

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_overlap.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_overlap.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_rrtmgp_cloud_overlap
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F
   dependencies = Radiation/radiation_tools.F90,Radiation/radiation_cloud_overlap.F90
 

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_pre.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_rrtmgp_pre
   type = scheme
-  relative_path	= ../../
+  dependencies_path	= ../../
   dependencies = tools/funcphys.f90,hooks/machine.F,Radiation/radiation_aerosols.f,photochem/module_ozphys.F90
   dependencies = Radiation/RRTMG/iounitdef.f,Radiation/radiation_astronomy.f,Radiation/radiation_gases.f,Radiation/radiation_tools.F90
 

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_setup.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_setup.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_rrtmgp_setup
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F,MP/module_mp_radar.F90,MP/Thompson/module_mp_thompson.F90
   dependencies = Radiation/radiation_aerosols.f,photochem/module_ozphys.F90
   dependencies = Radiation/radiation_gases.f,Radiation/RRTMG/iounitdef.f,Radiation/radiation_astronomy.f

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_4.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_4.meta
@@ -2,7 +2,7 @@
 [ccpp-table-properties]
   name = GFS_suite_interstitial_4
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F
   dependencies = MP/TEMPO/TEMPO/module_mp_tempo_utils.F90
   dependencies = MP/Thompson/module_mp_thompson_make_number_concentrations.F90

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_composites_post.meta
@@ -2,7 +2,7 @@
 [ccpp-table-properties]
   name = GFS_surface_composites_post
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F,SFC_Layer/UFS/sfc_diff.f
 
 ########################################################################

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_pre.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_surface_generic_pre
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = hooks/machine.F,SFC_Models/Land/Noah/surface_perturbation.F90
 
 ########################################################################

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.fv3.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.fv3.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_time_vary_pre
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = tools/funcphys.f90,hooks/machine.F
 
 ########################################################################

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.scm.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_time_vary_pre.scm.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = GFS_time_vary_pre
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = tools/funcphys.f90,hooks/machine.F
 
 ########################################################################

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/sgscloud_radpre.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/sgscloud_radpre.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = sgscloud_radpre
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = tools/funcphys.f90,hooks/machine.F
   dependencies = hooks/physcons.F90,Radiation/RRTMG/radcons.f90
   dependencies = Radiation/radiation_clouds.f,MP/module_mp_radar.F90,MP/Thompson/module_mp_thompson.F90

--- a/physics/SFC_Layer/UFS/sfc_diag.meta
+++ b/physics/SFC_Layer/UFS/sfc_diag.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = sfc_diag
   type = scheme
-  relative_path = ../../
+  dependencies_path = ../../
   dependencies = tools/funcphys.f90,hooks/machine.F,hooks/physcons.F90
 
 ########################################################################

--- a/physics/SFC_Layer/UFS/sfc_diag_post.meta
+++ b/physics/SFC_Layer/UFS/sfc_diag_post.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = sfc_diag_post
   type = scheme
-  relative_path	= ../../
+  dependencies_path	= ../../
   dependencies = hooks/machine.F
 
 ########################################################################

--- a/physics/SFC_Layer/UFS/sfc_diff.meta
+++ b/physics/SFC_Layer/UFS/sfc_diff.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = sfc_diff
   type = scheme
-  relative_path	= ../../
+  dependencies_path	= ../../
   dependencies = hooks/machine.F
 
 ########################################################################

--- a/physics/SFC_Models/SeaIce/CICE/sfc_cice.meta
+++ b/physics/SFC_Models/SeaIce/CICE/sfc_cice.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = sfc_cice
   type = scheme
-  relative_path	= ../../../
+  dependencies_path	= ../../../
   dependencies = hooks/machine.F
 
 ########################################################################

--- a/physics/SFC_Models/SeaIce/CICE/sfc_sice.meta
+++ b/physics/SFC_Models/SeaIce/CICE/sfc_sice.meta
@@ -1,7 +1,7 @@
 [ccpp-table-properties]
   name = sfc_sice
   type = scheme
-  relative_path	= ../../../
+  dependencies_path	= ../../../
   dependencies = tools/funcphys.f90,hooks/machine.F
 
 ########################################################################


### PR DESCRIPTION
## Description of Changes:

This PR changes the option `relative_path` in the CCPP metadata to `dependencies_path` as discussed in https://github.com/NCAR/ccpp-framework/issues/685.

## Tests Conducted:

**Todo: ufs-weather-model regression tests - see https://github.com/ufs-community/ufs-weather-model/pull/2983**

Corresponding ccpp-framework PR is https://github.com/NCAR/ccpp-framework/issues/685 (branch `climbfuji:feature/rel_path_dep_path`), which will be merged into NCAR ccpp-framework `develop` first (i.e. not `main`). This might be good opportunity to switch to the `develop` branch of NCAR ccpp-framework instead of `main`.

## Dependencies:

If not switching to NCAR ccpp-framework `develop` in the future, then wait until https://github.com/NCAR/ccpp-framework/pull/693 is merged and `main` is updated from `develop` (we will hopefully stop this antiquated two-branch business in ccpp-framework soon).

## Documentation:

**Todo: CCPP tech doc (who?)**

## Issue (optional):

https://github.com/NCAR/ccpp-framework/issues/685

## Contributors (optional):

n/a