### PR TITLE
Allow ihr to be non-multiples of 6

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/sfcsub.F
@@ -8749,13 +8749,10 @@ cjfe
 !
 !  no matching ih found. search nearest hour
 !
-        if(ihr.eq.6) then
+        if(ihr.gt.0.and.ihr.le.12) then
           ihr=0
           go to 50
-        elseif(ihr.eq.12) then
-          ihr=0
-          go to 50
-        elseif(ihr.eq.18) then
+        elseif(ihr.gt.0.and.ihr.le.23) then
           ihr=12
           go to 50
         elseif(ihr.eq.0.or.ihr.eq.-1) then


### PR DESCRIPTION
## Description of Changes:
The seaice file for the 06Z GFS cycle is updated When running IAU surface updates for the GFS, input hours can be multiples of 3. This results in an error in sfcsub.F when the input data time is on a previous day (as described in https://github.com/NOAA-EMC/global-workflow/issues/4364). Additionally, if the forecast cycle is not on 0, 6, 12, or 18 (which may happen at some point), global_cycle will need to perform updates on hours that are not a multiple of 6. This PR allows global_cycle to be run at any hour.

## Tests Conducted:
Tested this in the global-workflow for a C96 ATM-only 3DVar case on cycle 2021122106 where the seaice input grib file was valid at 2021122000. This change allowed the surface analysis to run successfully and for future cycles to run successfully as well.

All UFS_Utils unit and regression tests passed.

## Documentation:
N/A

## Issue (optional):
Refs https://github.com/NOAA-EMC/global-workflow/issues/4364

## Contributors (optional):
@jiaruidong2017 @russtreadon-noaa @ClaraDraper-NOAA 