### PR TITLE
Modified 'dtfac' OGWD tendency limiter in drag_suite_psl to match that in drag_suite_run

### DIFF
--- a/physics/GWD/drag_suite.F90
+++ b/physics/GWD/drag_suite.F90
@@ -2551,17 +2551,20 @@ IF ( (do_gsl_drag_ls_bl) .and.                                       &
             endif
          enddo
 !
-         do k = kts,km
-
             ! Check if well into mesosphere -- if so, perform similar reduction of
             ! velocity tendency due to mesoscale GWD to prevent sudden reversal of
             ! wind direction (similar to above)
-            dtfac_meso = 1.0
+         dtfac_meso = 1.0
+         do k = kts,km-1
+
             if (prsl(i,k).le.plolevmeso) then 
                if (taud_ls(i,k).ne.0.)                                  &    
                   dtfac_meso = min(dtfac_meso,facmeso*abs(velco(i,k)    &    
                      /(deltim*rcs*taud_ls(i,k))))
             end if
+          enddo
+
+         do k = kts,km-1
 
             taud_ls(i,k)  = taud_ls(i,k)*dtfac(i)*dtfac_meso*           &    
                                ls_taper(i) *(1.-rstoch(i))

--- a/physics/GWD/drag_suite.F90
+++ b/physics/GWD/drag_suite.F90
@@ -1119,8 +1119,8 @@ IF ( (do_gsl_drag_ls_bl) .and.                                       &
             ! wind direction (similar to above)
             dtfac_meso = 1.0
             if (prsl(i,k).le.plolevmeso) then
-               if (taud_ms(i,k).ne.0.)                                  &
-                  dtfac_meso = min(dtfac_meso,facmeso*abs(velco(i,k)    &
+               if (taud_ms(i,k).ne.0.)                                          &
+                  dtfac_meso = min(dtfac_meso,facmeso*abs(velco(i,min(k,km-1))  &
                      /(deltim*rcs*taud_ms(i,k))))
             end if
 
@@ -2551,20 +2551,17 @@ IF ( (do_gsl_drag_ls_bl) .and.                                       &
             endif
          enddo
 !
+         do k = kts,km
+
             ! Check if well into mesosphere -- if so, perform similar reduction of
             ! velocity tendency due to mesoscale GWD to prevent sudden reversal of
             ! wind direction (similar to above)
-         dtfac_meso = 1.0
-         do k = kts,km-1
-
+            dtfac_meso = 1.0
             if (prsl(i,k).le.plolevmeso) then 
-               if (taud_ls(i,k).ne.0.)                                  &    
-                  dtfac_meso = min(dtfac_meso,facmeso*abs(velco(i,k)    &    
+               if (taud_ls(i,k).ne.0.)                                          &
+                  dtfac_meso = min(dtfac_meso,facmeso*abs(velco(i,min(k,km-1))  &
                      /(deltim*rcs*taud_ls(i,k))))
             end if
-          enddo
-
-         do k = kts,km
 
             taud_ls(i,k)  = taud_ls(i,k)*dtfac(i)*dtfac_meso*           &    
                                ls_taper(i) *(1.-rstoch(i))

--- a/physics/GWD/drag_suite.F90
+++ b/physics/GWD/drag_suite.F90
@@ -2564,7 +2564,7 @@ IF ( (do_gsl_drag_ls_bl) .and.                                       &
             end if
           enddo
 
-         do k = kts,km-1
+         do k = kts,km
 
             taud_ls(i,k)  = taud_ls(i,k)*dtfac(i)*dtfac_meso*           &    
                                ls_taper(i) *(1.-rstoch(i))

--- a/physics/GWD/drag_suite.F90
+++ b/physics/GWD/drag_suite.F90
@@ -1691,7 +1691,6 @@ endif
                             bvf2,rdelks,wtkbj,tem,gfobnv,hd,fro,  &
                             rim,temc,tem1,efact,temv,dtaux,dtauy, &
                             dtauxb,dtauyb,eng0,eng1,dtfac_meso
-   real(kind=kind_phys) ::  denfac
 !
    logical              ::  ldrag(im),icrilv(im),                 &
                             flag(im)
@@ -1775,7 +1774,6 @@ endif
    fdir   = mdir / (2.0*pi)
    invgrcs = 1._kind_phys/g*rcs
    kpblmax = km / 2 ! maximum pbl height : # of vertical levels / 2
-   denfac = 1.0
 
    do i=1,im
       if (slmsk(i)==1. .or. slmsk(i)==2.) then !sea/land/ice mask (=0/1/2) in FV3

--- a/physics/GWD/drag_suite.F90
+++ b/physics/GWD/drag_suite.F90
@@ -1674,10 +1674,9 @@ endif
    real(kind=kind_phys), parameter       ::  hmt_min = 50.
    real(kind=kind_phys), parameter       ::  oc_min  = 1.0
    real(kind=kind_phys), parameter       ::  oc_max  = 10.0
-! 7.5 mb -- 33 km ... 0.01 kgm-3 reduce gwd drag above cutoff level
-   real(kind=kind_phys), parameter       ::  pcutoff  = 7.5e2  
-! 0.76 mb -- 50 km ...0.001 kgm-3  --- 0.1 mb 65 km 0.0001 kgm-3
-   real(kind=kind_phys), parameter       ::  pcutoff_den  = 0.01  !  
+   real(kind=kind_phys), parameter       ::  sgmalolev  = 0.5  ! max sigma lvl for dtfac
+   real(kind=kind_phys), parameter       ::  plolevmeso = 70.0 ! pres lvl for mesosphere OGWD reduction (Pa)
+   real(kind=kind_phys), parameter       ::  facmeso    = 0.5  ! fractional velocity reduction for OGWD
 
    integer,parameter    ::  kpblmin = 2
 
@@ -1691,7 +1690,7 @@ endif
                             rcsks,wdir,ti,rdz,tem2,dw2,shr2,      &
                             bvf2,rdelks,wtkbj,tem,gfobnv,hd,fro,  &
                             rim,temc,tem1,efact,temv,dtaux,dtauy, &
-                            dtauxb,dtauyb,eng0,eng1
+                            dtauxb,dtauyb,eng0,eng1,dtfac_meso
    real(kind=kind_phys) ::  denfac
 !
    logical              ::  ldrag(im),icrilv(im),                 &
@@ -1706,7 +1705,7 @@ endif
                             rulow(im),bnv(im),                    &
                             oa(im),ol(im),oc(im),                 &
                             oass(im),olss(im),                    &
-                            roll(im),dtfac(im,km),                   &
+                            roll(im),dtfac(im),                   &
                             brvf(im),xlinv(im),                   &
                             delks(im),delks1(im),                 &
                             bnv2(im,km),usqj(im,km),              &
@@ -1861,6 +1860,7 @@ endif
      oass(i)       = 0.0
      olss(i)       = 0.0
      ulow (i)      = 0.0
+     dtfac(i)      = 1.0
      rstoch(i)     = 0.0
      ldrag(i)      = .false.
      icrilv(i)     = .false.
@@ -1877,7 +1877,6 @@ endif
        taud_bl(i,k) = 0.0
        dtaux2d(i,k) = 0.0
        dtauy2d(i,k) = 0.0
-       dtfac(i,k)   = 1.0
      enddo
    enddo
 !
@@ -2536,30 +2535,38 @@ IF ( (do_gsl_drag_ls_bl) .and.                                       &
             taud_bl(i,klcap) = taud_bl(i,klcap) * factop
          enddo
 !
-!  if the gravity wave drag would force a critical line
-!  in the lower ksmm1 layers during the next deltim timestep,
-!  then only apply drag until that critical line is reached.
+!  if the gravity wave drag + blocking would force a critical line
+!  in the layers below pressure-based 'sigma' level = sgmalolev during the next deltim
+!  timestep, then only apply drag until that critical line is reached, i.e.,
+!  reduce drag to limit resulting wind components to zero
+!  Note: 'sigma' = prsi(k)/prsi(k=1), where prsi(k=1) is the surface pressure
 !
          do k = kts,kpblmax-1
-           if ((taud_ls(i,k)+taud_bl(i,k)).ne.0.)                  then
-               dtfac(i,k) = min(dtfac(i,k),abs(velco(i,k)                 &
+            if (prsi(i,k).ge.sgmalolev*prsi(i,1)) then 
+               if ((taud_ls(i,k)+taud_bl(i,k)).ne.0.)                   &
+                  dtfac(i) = min(dtfac(i),abs(velco(i,k)                &
                        /(deltim*rcs*(taud_ls(i,k)+taud_bl(i,k)))))
-           endif
-         enddo
-! apply limiter to mesosphere drag, reduce the drag by density factor 10-3
-! prevent wind reversal...
-!
-         do k = kpblmax,km-1
-           if ((taud_ls(i,k)+taud_bl(i,k)).ne.0..and.prsl(i,k).le.pcutoff) then
-               denfac = min(ro(i,k)/pcutoff_den,1.)
-               dtfac(i,k) = min(dtfac(i,k),denfac*abs(velco(i,k)          &
-                       /(deltim*rcs*(taud_ls(i,k)+taud_bl(i,k)))))
-           endif
+            else
+               exit
+            endif
          enddo
 !
          do k = kts,km
-            taud_ls(i,k)  = taud_ls(i,k)*dtfac(i,k)* ls_taper(i) *(1.-rstoch(i))
-            taud_bl(i,k)  = taud_bl(i,k)*dtfac(i,k)* ls_taper(i) *(1.-rstoch(i))
+
+            ! Check if well into mesosphere -- if so, perform similar reduction of
+            ! velocity tendency due to mesoscale GWD to prevent sudden reversal of
+            ! wind direction (similar to above)
+            dtfac_meso = 1.0
+            if (prsl(i,k).le.plolevmeso) then 
+               if (taud_ls(i,k).ne.0.)                                  &    
+                  dtfac_meso = min(dtfac_meso,facmeso*abs(velco(i,k)    &    
+                     /(deltim*rcs*taud_ls(i,k))))
+            end if
+
+            taud_ls(i,k)  = taud_ls(i,k)*dtfac(i)*dtfac_meso*           &    
+                               ls_taper(i) *(1.-rstoch(i))
+            taud_bl(i,k)  = taud_bl(i,k)*dtfac(i)* ls_taper(i) *(1.-rstoch(i))
+
             dtaux  = taud_ls(i,k) * xn(i)
             dtauy  = taud_ls(i,k) * yn(i)
             dtauxb = taud_bl(i,k) * xn(i)


### PR DESCRIPTION
## Description of Changes:
Modified 'dtfac' OGWD tendency limiter in drag_suite_psl to match that in drag_suite_run.

A tendency limiter is applied from surface to 500hPa, whereby all levels in a column are tested and a single tendency limiting factor ‘dtfac’ (real number between 0 and 1), which is determined from the level needing the most reduction, is applied to all levels.  The resulting ‘dtfac’ is multiplied by the OGWD tendency, providing the limiting reduction. 
An additional tendency limiter is applied above 0.7hPa (roughly corresponding to the mesosphere) that is similarly calculated as above.  The factor used for this limiter is ‘dtfac_meso’ (real number between 0 and 1).  It is calculated and applied level-by-level moving upward.  

This PR is similar to ccpp-physics PR[ #347](https://github.com/ufs-community/ccpp-physics/pull/347) except targeting the develop branch

## Tests Conducted:
It fixes GFSv17 model instability issue ([PPT](https://docs.google.com/presentation/d/1f7xQImzK1USkeVxghO23MBfKw2HjMuBCDMp-dcCfM4k/edit?usp=sharing))
## Dependencies:


## Documentation:


## Issue (optional):
Related to GFS v16 instability issue (https://github.com/NOAA-EMC/GFS/issues/46)

## Contributors (optional):
Mike Toy
