### PR TITLE
[production/RRFS.v1] Adds changes to save data table in RUCLSM, and reuse.

### DIFF
--- a/physics/SFC_Models/Land/RUC/lsm_ruc.F90
+++ b/physics/SFC_Models/Land/RUC/lsm_ruc.F90
@@ -1697,6 +1697,8 @@ module lsm_ruc
       integer,              dimension(1:lsoil)  :: sm_levels_input ! 4 - for Noah lsm
 
       integer :: ii,jj
+      real (kind_phys)      ::  cq,r61,r273,arp,brp,x,evs,eis
+
       ! Initialize the CCPP error handling variables
       errmsg = ''
       errflg = 0
@@ -1771,6 +1773,25 @@ module lsm_ruc
         endif
 
       else
+
+!> - Table TBQ is for resolution of balance equation in vilka()
+        CQ=173.15_kind_dbl_prec-.05_kind_dbl_prec
+        R273=1._kind_dbl_prec/con_t0c
+        R61=6.1153_kind_dbl_prec*0.62198_kind_dbl_prec
+        ARP=77455._kind_dbl_prec*41.9_kind_dbl_prec/461.525_kind_dbl_prec
+        BRP=64._kind_dbl_prec*41.9_kind_dbl_prec/461.525_kind_dbl_prec
+
+        DO K=1,5001
+          CQ=CQ+.05_kind_dbl_prec
+          EVS=EXP(17.67_kind_dbl_prec*(CQ-con_t0c)/(CQ-29.65_kind_dbl_prec))
+          EIS=EXP(22.514_kind_dbl_prec-6.15E3_kind_dbl_prec/CQ)
+          if(CQ.ge.con_t0c) then
+            ! tbq is in mb
+            tbq(k) = R61*evs
+          else
+            tbq(k) = R61*eis
+          endif
+        END DO
 
         ! For RUC restart data, return here
         return

--- a/physics/SFC_Models/Land/RUC/module_sf_ruclsm.F90
+++ b/physics/SFC_Models/Land/RUC/module_sf_ruclsm.F90
@@ -434,7 +434,6 @@ CONTAINS
 
    character(len=*),intent(out) :: errmsg
    integer,         intent(out) :: errflg
-   real (kind=8) :: walltime, tb, te
 
 !-----------------------------------------------------------------
 !   

--- a/physics/SFC_Models/Land/RUC/module_sf_ruclsm.F90
+++ b/physics/SFC_Models/Land/RUC/module_sf_ruclsm.F90
@@ -7348,9 +7348,7 @@ print *, 'SNOWTEMP: SNHEI,SNTH,SOILT1: ',SNHEI,SNTH,SOILT1,soilt
        tbq(k) = R61*eis
      endif
    END DO
-   write(6,'("ruclsminit: Done initializing tbq")')
-
-
+   
   END SUBROUTINE ruclsminit
 !
 !-----------------------------------------------------------------

--- a/physics/SFC_Models/Land/RUC/module_sf_ruclsm.F90
+++ b/physics/SFC_Models/Land/RUC/module_sf_ruclsm.F90
@@ -18,7 +18,7 @@ MODULE module_sf_ruclsm
    private
    !private qsn
 
-   public :: lsmruc, ruclsminit, rslf
+   public :: lsmruc, ruclsminit, rslf, tbq
 
 !> CONSTANT PARAMETERS
 !! @{
@@ -75,6 +75,7 @@ MODULE module_sf_ruclsm
                  REFKDT_DATA,FRZK_DATA,ZBOT_DATA,  SMLOW_DATA,SMHIGH_DATA, &
                         CZIL_DATA
 !! @}
+   real (kind_phys),     DIMENSION(1:5001)            :: tbq
 
 
 CONTAINS
@@ -381,9 +382,6 @@ CONTAINS
 
    real (kind_phys),     DIMENSION(1:2*(nsl-2))       :: DTDZS
 
-   real (kind_phys),     DIMENSION(1:5001)            :: TBQ
-
-
    real (kind_phys),     DIMENSION( 1:nsl )          :: SOILM1D, & 
                                                           TSO1D, &
                                                         SOILICE, &
@@ -436,6 +434,7 @@ CONTAINS
 
    character(len=*),intent(out) :: errmsg
    integer,         intent(out) :: errflg
+   real (kind=8) :: walltime, tb, te
 
 !-----------------------------------------------------------------
 !   
@@ -454,26 +453,6 @@ CONTAINS
         testptlat = 35.55 !48.7074_kind_phys !39.958 !42.05 !39.0 !74.12 !29.5 
         testptlon = 278.66 !289.03_kind_phys !271.622 !286.75 !280.6 !164.0 !283.0 
         !--
-
-
-!> - Table TBQ is for resolution of balance equation in vilka()
-        CQ=173.15_kind_dbl_prec-.05_kind_dbl_prec
-        R273=1._kind_dbl_prec/tfrz
-        R61=6.1153_kind_dbl_prec*0.62198_kind_dbl_prec
-        ARP=77455._kind_dbl_prec*41.9_kind_dbl_prec/461.525_kind_dbl_prec
-        BRP=64._kind_dbl_prec*41.9_kind_dbl_prec/461.525_kind_dbl_prec
-
-        DO K=1,5001
-          CQ=CQ+.05_kind_dbl_prec
-          EVS=EXP(17.67_kind_dbl_prec*(CQ-tfrz)/(CQ-29.65_kind_dbl_prec))
-          EIS=EXP(22.514_kind_dbl_prec-6.15E3_kind_dbl_prec/CQ)
-          if(CQ.ge.tfrz) then
-          ! tbq is in mb
-            tbq(k) = R61*evs
-          else
-            tbq(k) = R61*eis
-          endif
-        END DO
 
 !> - Initialize soil/vegetation parameters
 !--- This is temporary until SI is added to mass coordinate ---!!!!!
@@ -7261,8 +7240,9 @@ print *, 'SNOWTEMP: SNHEI,SNTH,SOILT1: ',SNHEI,SNTH,SOILT1,soilt
    !-- local
    real (kind_phys), DIMENSION ( 1:nzs ) :: SOILIQW
 
-   INTEGER ::  I,J,L,itf,jtf
+   INTEGER ::  I,J,L,K,itf,jtf
    real (kind_phys)    ::  RIW,XLMELT,TLN,DQM,REF,PSIS,QMIN,BCLH
+   real (kind_phys)      ::  cq,r61,r273,arp,brp,x,evs,eis
 
    INTEGER                   :: errflag
 
@@ -7349,6 +7329,26 @@ print *, 'SNOWTEMP: SNHEI,SNTH,SOILT1: ',SNHEI,SNTH,SOILT1,soilt
 
     ENDDO
    ENDDO
+
+!> - Table TBQ is for resolution of balance equation in vilka()
+   CQ=173.15_kind_dbl_prec-.05_kind_dbl_prec
+   R273=1._kind_dbl_prec/tfrz
+   R61=6.1153_kind_dbl_prec*0.62198_kind_dbl_prec
+   ARP=77455._kind_dbl_prec*41.9_kind_dbl_prec/461.525_kind_dbl_prec
+   BRP=64._kind_dbl_prec*41.9_kind_dbl_prec/461.525_kind_dbl_prec
+
+   DO K=1,5001
+     CQ=CQ+.05_kind_dbl_prec
+     EVS=EXP(17.67_kind_dbl_prec*(CQ-tfrz)/(CQ-29.65_kind_dbl_prec))
+     EIS=EXP(22.514_kind_dbl_prec-6.15E3_kind_dbl_prec/CQ)
+     if(CQ.ge.tfrz) then
+       ! tbq is in mb
+       tbq(k) = R61*evs
+     else
+       tbq(k) = R61*eis
+     endif
+   END DO
+   write(6,'("ruclsminit: Done initializing tbq")')
 
 
   END SUBROUTINE ruclsminit


### PR DESCRIPTION
## Description of Changes:

A profiling of the RRFS system led to a discovery that a certain data table in the RUCLSM was repeatedly generating the same data on each call to the routine.  This change only generates this data table once, then reuses it.  This makes RUCLSM based runs a good bit (maybe 5%) quicker.  Some timing results I shared with the person that provided the change:

"It seemed pretty consistently ~0.1 seconds faster per time step in these 103 node tests.  Would correspond to about 10 minutes faster over a 60 hour integration, which is a significant improvement. "

## Tests Conducted:

Ran the RRFS subset of UFS WM regression tests on WCOSS2, which all passed.  Is zero-diff change on answers.  https://github.com/ufs-community/ufs-weather-model/pull/3061

## Dependencies:

- [NOAA-EMC/ufsatm#<1057>](https://github.com/NOAA-EMC/ufsatm/pull/1057)
- [ufs-community/ufs-weather-model/#<3061>](https://github.com/ufs-community/ufs-weather-model/pull/3061)

## Documentation:

## Issue (optional):


## Contributors (optional):
@dkokron provided the RUCLSM speed up.  