### PR TITLE
RRFS smoke fix

### DIFF
--- a/physics/smoke_dust/rrfs_smoke_wrapper.F90
+++ b/physics/smoke_dust/rrfs_smoke_wrapper.F90
@@ -259,11 +259,13 @@ contains
         do i=1,im
           do k=kts,kte
             qgrs(i,k,ntfsmoke) = 0.
+            gq0(i,k,ntfsmoke) = 0.
           end do
         end do
       endif
       do i=1,im
         qgrs(i,kts,ntfsmoke) = qgrs(i,kts,ntfsmoke) + smoke_fire(i)
+        gq0(i,kts,ntfsmoke) = gq0(i,kts,ntfsmoke) + smoke_fire(i)
       end do
     endif
 


### PR DESCRIPTION
## Description of Changes:
This PR fixes an issue in the current UFS code where the smoke emissions from the CFBM fire_behavior module do not persist in subsequent timesteps. Only a few instantaneous pixels of smoke can be seen in the first layer. This series of images shows smoke concentrations in the first layer at 3 h, 4 h, 5h and 6 h lead times using the current UFS weather model code:
<img width="468" height="127" alt="image" src="https://github.com/user-attachments/assets/ec4f9031-a7b2-4aae-b0db-bceebde0e17f" />

After the fix, smoke now accumulates properly in the atmosphere over time:
<img width="521" height="148" alt="image" src="https://github.com/user-attachments/assets/3d1808e5-718c-4d87-8aed-02a0baf97f24" />

## Tests Conducted:
Ran the above-mentioned UFS tests with fire model enabled to show that the problem is now fixed.

UFS regression tests on Ursa were successful: only expected changes to fire behavior test.

## Dependencies:
- https://github.com/NOAA-EMC/ufsatm/pull/1124
- https://github.com/ufs-community/ufs-weather-model/pull/3267

## Documentation:
No changes needed

## Issue:
- fixes https://github.com/ufs-community/ufs-weather-model/issues/3266 (once updates merged into ufs-weather-model)

## Contributors:
Fixes from Maria Frediani and Pedro Jimenez
