### PR TITLE
feat: add flag controlling catchem coupling

### DIFF
--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_PBL_generic_post.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_PBL_generic_post.F90
@@ -13,7 +13,7 @@
         tend_opt_pbl, trans_aero, ntchs, ntchm, ntccn, nthl, nthnc, ntgv, nthv, ntrz, ntgz, nthz, imp_physics,                 &
         imp_physics_gfdl, imp_physics_thompson, imp_physics_wsm6, imp_physics_mg, imp_physics_tempo, lthailaware,              &
         imp_physics_fer_hires, imp_physics_nssl, nssl_ccn_on, ltaerosol, mraerosol, nssl_hail_on, nssl_3moment,                &
-        cplflx, cplaqm, cplchm, lssav, flag_for_pbl_generic_tend, ldiag3d, lsidea, hybedmf, do_shoc, satmedmf,                 &
+        cplflx, cplaqm, cplchm, cplcat, lssav, flag_for_pbl_generic_tend, ldiag3d, lsidea, hybedmf, do_shoc, satmedmf,         &
         shinhong, do_ysu, dvdftra, ten_t_pbl, ten_q_pbl, ten_t, ten_u, ten_v, ten_q, dusfc1, dvsfc1, dtsfc1, dqsfc1, dtf, dtp, &
         dudt, dvdt, dtdt, dqdt, dusfc_cpl, dvsfc_cpl, dtsfc_cpl, dtend, dtidx, index_of_temperature, index_of_x_wind,          &
         index_of_y_wind, index_of_process_pbl, dqsfc_cpl, dusfci_cpl, dvsfci_cpl, dtsfci_cpl, dqsfci_cpl, dusfc_diag,          &
@@ -38,7 +38,7 @@
       integer, intent(in) :: imp_physics_mg, imp_physics_fer_hires
       integer, intent(in) :: imp_physics_nssl
       logical, intent(in) :: nssl_ccn_on, nssl_hail_on, nssl_3moment
-      logical, intent(in) :: ltaerosol, cplflx, cplaqm, cplchm, lssav, ldiag3d, lsidea, use_med_flux, mraerosol, lthailaware
+      logical, intent(in) :: ltaerosol, cplflx, cplaqm, cplchm, cplcat, lssav, ldiag3d, lsidea, use_med_flux, mraerosol, lthailaware
       logical, intent(in) :: hybedmf, do_shoc, satmedmf, shinhong, do_ysu
 
       logical, intent(in) :: flag_for_pbl_generic_tend      
@@ -206,7 +206,7 @@
               enddo
             enddo
           endif
-        elseif (imp_physics == imp_physics_tempo) then         
+        elseif (imp_physics == imp_physics_tempo) then
   ! Tempo
           do k=1,levs
              do i=1,im
@@ -221,7 +221,7 @@
                 dqdt(i,k,ntoz)  = dvdftra(i,k,9)
              enddo
           enddo
-          
+
           n = 10
           if (ltaerosol) then
              do k=1,levs
@@ -233,16 +233,16 @@
              enddo
              n = 13
           endif
-         
+
           if (lthailaware) then
              do k=1,levs
-                do i=1,im          
+                do i=1,im
                    dqdt(i,k,ntgnc) = dvdftra(i,k,n)
                    dqdt(i,k,ntgv) = dvdftra(i,k,n+1)
                 enddo
              enddo
           endif
-          
+
         elseif (imp_physics == imp_physics_mg) then          ! MG3/2
           if (ntgl > 0) then                                 ! MG
             do k=1,levs
@@ -473,7 +473,7 @@
         enddo
       endif
 
-      if (cplchm) then
+      if (cplchm .or. cplcat) then
         if (cplflx) then
           do i = 1, im
             if (oceanfrac(i) > zero) then
@@ -491,7 +491,7 @@
         end if
       end if
 
-      if (cplaqm) then
+      if (cplaqm .or. cplcat) then
         do i = 1, im
           if (oceanfrac(i) > zero) then
             if (.not.cplflx) then
@@ -562,7 +562,7 @@
             ten_q_pbl(i,k)=ten_q(i,k,ntqv)
          end do
       end do
-      
+
       end subroutine GFS_PBL_generic_post_run
 
       end module GFS_PBL_generic_post

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_PBL_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_PBL_generic_post.meta
@@ -358,6 +358,13 @@
   dimensions = ()
   type = logical
   intent = in
+[cplcat]
+  standard_name = flag_for_catchem_coupling
+  long_name = flag controlling cplcat collection (default off)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [lssav]
   standard_name = flag_for_diagnostics
   long_name = logical flag for storing diagnostics

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_post.F90
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_post.F90
@@ -45,7 +45,7 @@
 !> \section arg_table_GFS_surface_generic_post_run Argument Table
 !! \htmlinclude GFS_surface_generic_post_run.html
 !!
-      subroutine GFS_surface_generic_post_run (im, cplflx, cplaqm, cplchm, cplwav, cpllnd, cpl_fire, lssav, dry, icy, wet,          &
+      subroutine GFS_surface_generic_post_run (im, cplflx, cplaqm, cplchm, cplcat, cplwav, cpllnd, cpl_fire, lssav, dry, icy, wet,          &
         lsm, lsm_noahmp, dtf, ep1d, gflx, tgrs_1, qgrs_1, ugrs_1, vgrs_1,                                                           &
         adjsfcdlw, adjsfcdsw, adjnirbmd, adjnirdfd, adjvisbmd, adjvisdfd, adjsfculw, adjsfculw_wat, adjnirbmu, adjnirdfu,           &
         adjvisbmu, adjvisdfu, t2m, q2m, u10m, v10m, tsfc, tsfc_wat, pgr, xcosz, evbs, evcw, trans, sbsno, snowc, snohf, pah, pahi,  &
@@ -59,7 +59,7 @@
         implicit none
 
         integer,                                intent(in) :: im
-        logical,                                intent(in) :: cplflx, cplaqm, cplchm, cplwav, cpllnd, cpl_fire, lssav
+        logical,                                intent(in) :: cplflx, cplaqm, cplchm, cplcat, cplwav, cpllnd, cpl_fire, lssav
         logical, dimension(:),                  intent(in) :: dry, icy, wet
         integer,                                intent(in) :: lsm, lsm_noahmp
         real(kind=kind_phys),                   intent(in) :: dtf
@@ -117,14 +117,14 @@
           v1(i)     = vgrs_1(i)
         enddo
 
-        if (cplflx .or. cplchm .or. cplwav .or. cpl_fire) then
+        if (cplflx .or. cplchm .or. cplcat .or. cplwav .or. cpl_fire) then
           do i=1,im
             u10mi_cpl(i) = u10m(i)
             v10mi_cpl(i) = v10m(i)
           enddo
         endif
 
-        if (cplflx .or. cplchm .or. cpllnd) then
+        if (cplflx .or. cplchm .or. cplcat .or. cpllnd) then
           do i=1,im
             tsfci_cpl(i) = tsfc(i)
           enddo
@@ -205,7 +205,7 @@
           enddo
         endif
 
-        if (cplaqm .and. .not.cplflx) then
+        if ((cplaqm .and. .not.cplflx) .or. cplcat) then
           do i=1,im
             t2mi_cpl    (i) = t2m(i)
             q2mi_cpl    (i) = q2m(i)

--- a/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_post.meta
+++ b/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_surface_generic_post.meta
@@ -112,6 +112,13 @@
   dimensions = ()
   type = logical
   intent = in
+[cplcat]
+  standard_name = flag_for_catchem_coupling
+  long_name = flag controlling cplcat collection (default off)
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [cplwav]
   standard_name = flag_for_ocean_wave_coupling
   long_name = flag controlling cplwav collection (default off)


### PR DESCRIPTION
## Description of Changes:
[CATChem](https://github.com/ufs-community/CATChem) is being added as a WM atmospheric composition component to support a future GCAFS (Global Chemistry and Aerosol Forecast System) version. CATChem's field requirements differ slightly from the other atmospheric composition modeling components (UFS-AQM, GOCART). Hence, the additional coupling flag.

## Tests Conducted:
A new WM test was added (`catchem_control`) exercising the new coupling flag (see https://github.com/ufs-community/ufs-weather-model/pull/3223).
- Tested on Ursa with IntelLLVM. CATChem with [`gcc-12` compiles/tests in the repo's CI](https://github.com/ufs-community/CATChem/commit/06bf6700608d585a0ae8c45e94e8f77c6708fe73).

## Dependencies:
N/A

## Documentation:
I don't think new documentation is required for the flag.

## Issue (optional):
xref: https://github.com/ufs-community/CATChem/issues/140

## Contributors (optional):
@lwcugb